### PR TITLE
[JENKINS-50216] - Make RemotableGoogleCredentials compatible with JEP-200 in Jenkins 2.102+

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,2 @@
+// Build the plugin using https://github.com/jenkins-infra/pipeline-library
+buildPlugin(jenkinsVersions: [null, '2.107.2'], failFast: false)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,2 +1,2 @@
 // Build the plugin using https://github.com/jenkins-infra/pipeline-library
-buildPlugin(jenkinsVersions: [null, '2.107.2'], failFast: false)
+buildPlugin(platforms: ['linux'], jenkinsVersions: [null, '2.107.2'], failFast: false)

--- a/checkstyleJavaHeader
+++ b/checkstyleJavaHeader
@@ -1,5 +1,5 @@
 ^/\*$
-^ \* Copyright 201(3|4|5) Google Inc\. All Rights Reserved\.$
+^ \* Copyright 201(3|4|5|6|7|8) .*$
 ^ \*$
 ^ \* Licensed under the Apache License, Version 2\.0 \(the \"License\"\);$
 ^ \* you may not use this file except in compliance with the License\.$

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.5</version>
+    <version>3.8</version>
   </parent>
 
   <!--
@@ -143,6 +143,8 @@
     <jenkins.version>1.653</jenkins.version>
     <google.api.version>1.22.0</google.api.version>
     <java.level>7</java.level>
+    <!-- TODO: Currently checkstyle fails even for the 'master' branch code. It also prohibits code not Copyrighted by Google-->
+    <checkstyle.skip>true</checkstyle.skip>
   </properties>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -92,24 +92,6 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>findbugs-maven-plugin</artifactId>
-        <version>3.0.5</version>
-        <configuration>
-          <effort>Max</effort>
-          <threshold>Medium</threshold>
-          <xmlOutput>true</xmlOutput>
-          <excludeFilterFile>findbugs-exclude.xml</excludeFilterFile>
-        </configuration>
-        <executions>
-          <execution>
-            <goals>
-              <goal>check</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
 	<groupId>org.codehaus.mojo</groupId>
 	<artifactId>cobertura-maven-plugin</artifactId>
 	<version>2.5.2</version>
@@ -143,6 +125,9 @@
     <jenkins.version>1.653</jenkins.version>
     <google.api.version>1.22.0</google.api.version>
     <java.level>7</java.level>
+    <findbugs.excludeFilterFile>findbugs-exclude.xml</findbugs.excludeFilterFile>
+    <findbugs.effort>Max</findbugs.effort>
+    <findbugs.threshold>Medium</findbugs.threshold>
   </properties>
 
   <dependencies>
@@ -178,11 +163,6 @@
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-library</artifactId>
       <version>1.3</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -235,6 +235,17 @@
       <version>1.16.1</version>
       <scope>compile</scope>
     </dependency>
+    <dependency>
+      <!-- Required to run P12ServiceAccountConfigTestUtil-dependent tests against newer Jenkins core versions.
+           Dependency on it does not cause issues in the baseline core even though the plugin is formally incompatible.
+           Should it break at some point, the core requirement can be bumped to 2.17.x.
+           The BC library can be also shaded if the core requirement needs to be retained.
+       -->
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>bouncycastle-api</artifactId>
+      <version>2.16.2</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>2.5</version>
+    <version>3.5</version>
   </parent>
 
   <!--
@@ -32,7 +32,7 @@
   <description>
     This plugin implements the OAuth Credentials interfaces to surface Google Service Account credentials to Jenkins.
   </description>
-  <url>http://wiki.jenkins-ci.org/display/JENKINS/Google+OAuth+Plugin</url>
+  <url>https://wiki.jenkins.io/display/JENKINS/Google+OAuth+Plugin</url>
   <licenses>
     <license>
       <name>The Apache V2 License</name>
@@ -58,37 +58,19 @@
   <repositories>
     <repository>
       <id>repo.jenkins-ci.org</id>
-      <url>http://repo.jenkins-ci.org/public/</url>
+      <url>https://repo.jenkins-ci.org/public/</url>
     </repository>
   </repositories>
 
   <pluginRepositories>
     <pluginRepository>
       <id>repo.jenkins-ci.org</id>
-      <url>http://repo.jenkins-ci.org/public/</url>
+      <url>https://repo.jenkins-ci.org/public/</url>
     </pluginRepository>
   </pluginRepositories>
 
   <build>
     <plugins>
-      <plugin>
-	<groupId>org.apache.maven.plugins</groupId>
-	<artifactId>maven-compiler-plugin</artifactId>
-	<version>3.1</version>
-	<configuration>
-	  <source>1.6</source>
-	  <target>1.6</target>
-        </configuration>
-      </plugin>
-      <plugin>
-	<groupId>org.jenkins-ci.tools</groupId>
-	<artifactId>maven-hpi-plugin</artifactId>
-	<version>1.96</version>
-	<extensions>true</extensions>
-	<configuration>
-	  <disabledTestInjection>true</disabledTestInjection>
-	</configuration>
-      </plugin>
       <plugin>
 	<groupId>org.apache.maven.plugins</groupId>
 	<artifactId>maven-checkstyle-plugin</artifactId>
@@ -112,7 +94,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>findbugs-maven-plugin</artifactId>
-        <version>3.0.1</version>
+        <version>3.0.5</version>
         <configuration>
           <effort>Max</effort>
           <threshold>Medium</threshold>
@@ -160,6 +142,7 @@
   <properties>
     <jenkins.version>1.653</jenkins.version>
     <google.api.version>1.22.0</google.api.version>
+    <java.level>7</java.level>
   </properties>
 
   <dependencies>
@@ -200,7 +183,6 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.11</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -143,8 +143,6 @@
     <jenkins.version>1.653</jenkins.version>
     <google.api.version>1.22.0</google.api.version>
     <java.level>7</java.level>
-    <!-- TODO: Currently checkstyle fails even for the 'master' branch code. It also prohibits code not Copyrighted by Google-->
-    <checkstyle.skip>true</checkstyle.skip>
   </properties>
 
   <dependencies>

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/RemotableGoogleCredentials.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/RemotableGoogleCredentials.java
@@ -79,7 +79,9 @@ final class RemotableGoogleCredentials extends GoogleRobotCredentials {
       throw new GeneralSecurityException(
           Messages.RemotableGoogleCredentials_NoAccessToken(), e);
     }
-    this.accessToken = mock ? "MOCKED" : checkNotNull(credential.getAccessToken());
+    this.accessToken = mock
+            ? "MOCKED"
+            : checkNotNull(credential.getAccessToken());
     this.expiration = new DateTime().plusSeconds(
         checkNotNull(credential.getExpiresInSeconds()).intValue());
   }
@@ -111,7 +113,8 @@ final class RemotableGoogleCredentials extends GoogleRobotCredentials {
 
   /**
    * Gets expiration time of the credentials token.
-   * @return Expiration time. {@code null} if time is not set, Token will be considered as expired.
+   * @return Expiration time. {@code null} if time is not set,
+   *         token will be considered as expired.
    * @since TODO
    */
   @CheckForNull
@@ -122,7 +125,8 @@ final class RemotableGoogleCredentials extends GoogleRobotCredentials {
   /**
    * Check if token is expired.
    * @return {@code true} if token is expired.
-   *         If {@link #expiration} deserialization fails, the token is always expired
+   *         If {@link #expiration} deserialization fails,
+   *         the token is always expired
    * @since TODO
    */
   public boolean isTokenExpired() {

--- a/src/main/java/com/google/jenkins/plugins/util/JodaDateTimeConverter.java
+++ b/src/main/java/com/google/jenkins/plugins/util/JodaDateTimeConverter.java
@@ -1,0 +1,99 @@
+package com.google.jenkins.plugins.util;
+
+
+import com.thoughtworks.xstream.converters.Converter;
+import com.thoughtworks.xstream.converters.MarshallingContext;
+import com.thoughtworks.xstream.converters.UnmarshallingContext;
+import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
+import hudson.init.InitMilestone;
+import hudson.init.Initializer;
+import jenkins.model.Jenkins;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.slf4j.event.Level;
+
+import java.util.TimeZone;
+import java.util.logging.Logger;
+
+/**
+ * @author Oleg Nenashev
+ * @since TODO
+ */
+public class JodaDateTimeConverter implements Converter {
+
+    private static final Logger LOGGER = Logger.getLogger(JodaDateTimeConverter.class.getName());
+
+    @Initializer(before = InitMilestone.PLUGINS_LISTED)
+    public static void initConverter() {
+        // Overrides the default converters
+        Jenkins.XSTREAM2.registerConverter(new JodaDateTimeConverter(), 10);
+    }
+
+    @Override
+    public void marshal(Object source, HierarchicalStreamWriter writer, MarshallingContext context) {
+        DateTime value = (DateTime)source;
+        writer.addAttribute("millis", Long.toString(value.getMillis()));
+        writer.addAttribute("timezone", value.getChronology().getZone().getID());
+    }
+
+    @Override
+    public Object unmarshal(HierarchicalStreamReader reader, UnmarshallingContext context) {
+        String millis = reader.getAttribute("millis");
+        if (millis != null) { // new format
+            String timezone = reader.getAttribute("timezone");
+            Long val = Long.parseLong(millis);
+            DateTimeZone tz = timezone != null ? DateTimeZone.forID(timezone) : null;
+            return new DateTime(val, tz);
+        }
+
+        //TODO: this thing may not work for other ISOChronology implementations, but in such case we will get null
+        // Old format
+        // <iMillis>1523889095013</iMillis>
+        // <iChronology class="org.joda.time.chrono.ISOChronology" resolves-to="org.joda.time.chrono.ISOChronology$Stub" serialization="custom">
+        //   <org.joda.time.chrono.ISOChronology_-Stub>
+        //     <org.joda.time.tz.CachedDateTimeZone resolves-to="org.joda.time.DateTimeZone$Stub" serialization="custom">
+        //       <org.joda.time.DateTimeZone_-Stub>
+        //         <string>Europe/Zurich</string>
+        //       </org.joda.time.DateTimeZone_-Stub>
+        //     </org.joda.time.tz.CachedDateTimeZone>
+        //  </org.joda.time.chrono.ISOChronology_-Stub>
+        // </iChronology>
+        String timezone = null;
+        while (reader.hasMoreChildren()) {
+            reader.moveDown();
+            String name = reader.getNodeName();
+            if (name.equals("iMillis")) {
+                millis = reader.getValue();
+            } else if (name.equals("iChronology")) {
+                reader.moveDown();
+                reader.moveDown();
+                reader.moveDown();
+                reader.moveDown();
+                if ("string".equals(reader.getNodeName())) {
+                    timezone = reader.getValue();
+                }
+                reader.moveUp();
+                reader.moveUp();
+                reader.moveUp();
+                reader.moveUp();
+            }
+            reader.moveUp();
+        }
+        if (millis != null && timezone != null) {
+            Long val = Long.parseLong(millis);
+            DateTimeZone tz = DateTimeZone.forID(timezone);
+            return new DateTime(val, tz);
+        }
+
+        //TODO: throw something meaningful?
+        throw new IllegalStateException("Unsupported format for: " + DateTime.class + " in " + context.currentObject());
+    }
+
+    @Override
+    public boolean canConvert(Class type) {
+        return DateTime.class == type;
+    }
+
+
+}

--- a/src/main/java/com/google/jenkins/plugins/util/JodaDateTimeConverter.java
+++ b/src/main/java/com/google/jenkins/plugins/util/JodaDateTimeConverter.java
@@ -20,7 +20,6 @@ import java.util.logging.Logger;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 
-import com.thoughtworks.xstream.XStream;
 import com.thoughtworks.xstream.converters.Converter;
 import com.thoughtworks.xstream.converters.MarshallingContext;
 import com.thoughtworks.xstream.converters.UnmarshallingContext;
@@ -43,8 +42,7 @@ public class JodaDateTimeConverter implements Converter {
     @Initializer(before = InitMilestone.PLUGINS_LISTED)
     public static void initConverter() {
         // Overrides the default converters, runs before the JEP-200 blacklist
-        Jenkins.XSTREAM2.registerConverter(new JodaDateTimeConverter(),
-                XStream.PRIORITY_VERY_HIGH + 1);
+        Jenkins.XSTREAM2.registerConverter(new JodaDateTimeConverter());
     }
 
     @Override

--- a/src/main/java/com/google/jenkins/plugins/util/JodaDateTimeConverter.java
+++ b/src/main/java/com/google/jenkins/plugins/util/JodaDateTimeConverter.java
@@ -20,6 +20,7 @@ import java.util.logging.Logger;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 
+import com.thoughtworks.xstream.XStream;
 import com.thoughtworks.xstream.converters.Converter;
 import com.thoughtworks.xstream.converters.MarshallingContext;
 import com.thoughtworks.xstream.converters.UnmarshallingContext;
@@ -41,8 +42,9 @@ public class JodaDateTimeConverter implements Converter {
 
     @Initializer(before = InitMilestone.PLUGINS_LISTED)
     public static void initConverter() {
-        // Overrides the default converters
-        Jenkins.XSTREAM2.registerConverter(new JodaDateTimeConverter(), 10);
+        // Overrides the default converters, runs before the JEP-200 blacklist
+        Jenkins.XSTREAM2.registerConverter(new JodaDateTimeConverter(),
+                XStream.PRIORITY_VERY_HIGH + 1);
     }
 
     @Override

--- a/src/main/resources/META-INF/hudson.remoting.ClassFilter
+++ b/src/main/resources/META-INF/hudson.remoting.ClassFilter
@@ -1,0 +1,2 @@
+# JENKINS-50216 - com.google.jenkins.plugins.util.JodaDateTimeConverter
+org.joda.time.DateTime

--- a/src/main/resources/com/google/jenkins/plugins/credentials/oauth/GoogleRobotMetadataCredentials/config.jelly
+++ b/src/main/resources/com/google/jenkins/plugins/credentials/oauth/GoogleRobotMetadataCredentials/config.jelly
@@ -13,6 +13,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
          xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
    <f:entry title="${%Project Name}" field="projectId">

--- a/src/main/resources/com/google/jenkins/plugins/credentials/oauth/GoogleRobotPrivateKeyCredentials/config.jelly
+++ b/src/main/resources/com/google/jenkins/plugins/credentials/oauth/GoogleRobotPrivateKeyCredentials/config.jelly
@@ -13,6 +13,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form">
   <f:entry title="${%Project Name}" field="projectId">
     <f:textbox />

--- a/src/main/resources/com/google/jenkins/plugins/credentials/oauth/JsonServiceAccountConfig/config.jelly
+++ b/src/main/resources/com/google/jenkins/plugins/credentials/oauth/JsonServiceAccountConfig/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core"
          xmlns:f="/lib/form">
   <f:entry field="jsonKeyFile"

--- a/src/main/resources/com/google/jenkins/plugins/credentials/oauth/P12ServiceAccountConfig/config.jelly
+++ b/src/main/resources/com/google/jenkins/plugins/credentials/oauth/P12ServiceAccountConfig/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core"
          xmlns:f="/lib/form">
   <f:entry field="emailAddress"

--- a/src/test/java/com/google/jenkins/plugins/credentials/oauth/RemotableGoogleCredentialsIntegrationTest.java
+++ b/src/test/java/com/google/jenkins/plugins/credentials/oauth/RemotableGoogleCredentialsIntegrationTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2018 CloudBees, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.jenkins.plugins.credentials.oauth;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Arrays;
+import java.util.Collection;
+
+import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import hudson.XmlFile;
+import jenkins.model.Jenkins;
+import org.joda.time.DateTime;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.jvnet.hudson.test.For;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests which involve real Jenkins instance.
+ * @author Oleg Nenashev
+ * @see RemotableGoogleCredentialsTest
+ */
+@For(RemotableGoogleCredentials.class)
+public class RemotableGoogleCredentialsIntegrationTest {
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Rule
+    public TemporaryFolder tmp = new TemporaryFolder();
+
+    @Test
+    @Issue("JENKINS-50216")
+    public void checkSerializationRoundtrip() throws Exception {
+        File file = new File(tmp.getRoot(), "remotableGoogleCredentials.xml");
+        XmlFile xml = new XmlFile(Jenkins.XSTREAM2, file);
+
+        GoogleCredential googleCredential = new GoogleCredential();
+        googleCredential.setExpiresInSeconds(120L);
+        GoogleRobotCredentials creds = new GoogleRobotCredentialsTest.FakeGoogleCredentials(
+                "myproject", googleCredential);
+
+        RemotableGoogleCredentials credentials = new RemotableGoogleCredentials(creds, new Requirement(), new GoogleRobotCredentialsModule(), true);
+        xml.write(credentials);
+
+        // now Reload it
+        RemotableGoogleCredentials read = (RemotableGoogleCredentials) xml.read();
+        assertFalse("Deserialized token should not be considered as expired", read.isTokenExpired());
+    }
+
+    @Test
+    @Issue("JENKINS-50216")
+    public void shouldDeserializeOldFormat() throws Exception {
+        File file = new File(tmp.getRoot(), "remotableGoogleCredentials.xml");
+        try (InputStream istream = RemotableGoogleCredentialsTest.class.getResourceAsStream("jodaDateTimeXML.xml");
+            OutputStream ostream = new FileOutputStream(file)) {
+            org.apache.commons.io.IOUtils.copy(istream, ostream);
+        }
+
+        XmlFile xml = new XmlFile(Jenkins.XSTREAM2, file);
+        RemotableGoogleCredentials read = (RemotableGoogleCredentials) xml.read();
+        DateTime expiration = read.getTokenExpirationTime();
+        assertNotNull("Expiration token should be read from the Old XML format", expiration);
+        assertEquals(1523889095013L, expiration.getMillis());
+        assertEquals("Europe/Zurich", expiration.getZone().getID());
+    }
+
+    @Test
+    @Issue("JENKINS-50216")
+    public void shouldDeserializeBrokenXMLAsNull() throws Exception {
+        File file = new File(tmp.getRoot(), "remotableGoogleCredentials.xml");
+        try (InputStream istream = RemotableGoogleCredentialsTest.class.getResourceAsStream("jodaDateTimeBroken.xml");
+            OutputStream ostream = new FileOutputStream(file)) {
+            org.apache.commons.io.IOUtils.copy(istream, ostream);
+        }
+
+        XmlFile xml = new XmlFile(Jenkins.XSTREAM2, file);
+        RemotableGoogleCredentials read = (RemotableGoogleCredentials) xml.read();
+        DateTime expiration = read.getTokenExpirationTime();
+        assertNull("Expiration token should be null", expiration);
+        assertTrue("Deserialized token should be considered as expired", read.isTokenExpired());
+    }
+
+    private static class Requirement extends GoogleOAuth2ScopeRequirement {
+
+        @Override
+        public Collection<String> getScopes() {
+            return Arrays.asList("foo", "bar");
+        }
+    }
+}

--- a/src/test/java/com/google/jenkins/plugins/credentials/oauth/RemotableGoogleCredentialsIntegrationTest.java
+++ b/src/test/java/com/google/jenkins/plugins/credentials/oauth/RemotableGoogleCredentialsIntegrationTest.java
@@ -121,6 +121,29 @@ public class RemotableGoogleCredentialsIntegrationTest {
                 read.isTokenExpired());
     }
 
+    @Test
+    @Issue("JENKINS-50216")
+    public void shouldRoundtripNulls() throws Exception {
+        File file = new File(tmp.getRoot(), "remotableGoogleCredentials.xml");
+        try (InputStream istream =
+                     RemotableGoogleCredentialsTest.class.getResourceAsStream(
+                             "jodaDateTimeNull.xml");
+             OutputStream ostream = new FileOutputStream(file)) {
+            org.apache.commons.io.IOUtils.copy(istream, ostream);
+        }
+
+        XmlFile xml = new XmlFile(Jenkins.XSTREAM2, file);
+        RemotableGoogleCredentials read =
+                (RemotableGoogleCredentials) xml.read();
+        DateTime expiration = read.getTokenExpirationTime();
+        assertNull("Expiration token should be null", expiration);
+        assertTrue("Deserialized token should be considered as expired",
+                read.isTokenExpired());
+
+        // Write it back
+        xml.write(read);
+    }
+
     private static class Requirement extends GoogleOAuth2ScopeRequirement {
 
         @Override

--- a/src/test/java/com/google/jenkins/plugins/credentials/oauth/RemotableGoogleCredentialsIntegrationTest.java
+++ b/src/test/java/com/google/jenkins/plugins/credentials/oauth/RemotableGoogleCredentialsIntegrationTest.java
@@ -22,9 +22,12 @@ import java.io.OutputStream;
 import java.util.Arrays;
 import java.util.Collection;
 
-import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
-import hudson.XmlFile;
-import jenkins.model.Jenkins;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
 import org.joda.time.DateTime;
 import org.junit.Rule;
 import org.junit.Test;
@@ -33,11 +36,9 @@ import org.jvnet.hudson.test.For;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import hudson.XmlFile;
+import jenkins.model.Jenkins;
 
 /**
  * Tests which involve real Jenkins instance.
@@ -61,30 +62,41 @@ public class RemotableGoogleCredentialsIntegrationTest {
 
         GoogleCredential googleCredential = new GoogleCredential();
         googleCredential.setExpiresInSeconds(120L);
-        GoogleRobotCredentials creds = new GoogleRobotCredentialsTest.FakeGoogleCredentials(
+        GoogleRobotCredentials creds =
+                new GoogleRobotCredentialsTest.FakeGoogleCredentials(
                 "myproject", googleCredential);
 
-        RemotableGoogleCredentials credentials = new RemotableGoogleCredentials(creds, new Requirement(), new GoogleRobotCredentialsModule(), true);
+        RemotableGoogleCredentials credentials =
+                new RemotableGoogleCredentials(creds, new Requirement(),
+                        new GoogleRobotCredentialsModule(), true);
         xml.write(credentials);
 
         // now Reload it
-        RemotableGoogleCredentials read = (RemotableGoogleCredentials) xml.read();
-        assertFalse("Deserialized token should not be considered as expired", read.isTokenExpired());
+        RemotableGoogleCredentials read =
+                (RemotableGoogleCredentials) xml.read();
+        assertFalse(
+                "Deserialized token should not be considered as expired",
+                read.isTokenExpired());
     }
 
     @Test
     @Issue("JENKINS-50216")
     public void shouldDeserializeOldFormat() throws Exception {
         File file = new File(tmp.getRoot(), "remotableGoogleCredentials.xml");
-        try (InputStream istream = RemotableGoogleCredentialsTest.class.getResourceAsStream("jodaDateTimeXML.xml");
+        try (InputStream istream =
+                     RemotableGoogleCredentialsTest.class.getResourceAsStream(
+                             "jodaDateTimeXML.xml");
             OutputStream ostream = new FileOutputStream(file)) {
             org.apache.commons.io.IOUtils.copy(istream, ostream);
         }
 
         XmlFile xml = new XmlFile(Jenkins.XSTREAM2, file);
-        RemotableGoogleCredentials read = (RemotableGoogleCredentials) xml.read();
+        RemotableGoogleCredentials read =
+                (RemotableGoogleCredentials) xml.read();
         DateTime expiration = read.getTokenExpirationTime();
-        assertNotNull("Expiration token should be read from the Old XML format", expiration);
+        assertNotNull(
+                "Expiration token should be read from the Old XML format",
+                expiration);
         assertEquals(1523889095013L, expiration.getMillis());
         assertEquals("Europe/Zurich", expiration.getZone().getID());
     }
@@ -93,16 +105,20 @@ public class RemotableGoogleCredentialsIntegrationTest {
     @Issue("JENKINS-50216")
     public void shouldDeserializeBrokenXMLAsNull() throws Exception {
         File file = new File(tmp.getRoot(), "remotableGoogleCredentials.xml");
-        try (InputStream istream = RemotableGoogleCredentialsTest.class.getResourceAsStream("jodaDateTimeBroken.xml");
+        try (InputStream istream =
+                     RemotableGoogleCredentialsTest.class.getResourceAsStream(
+                             "jodaDateTimeBroken.xml");
             OutputStream ostream = new FileOutputStream(file)) {
             org.apache.commons.io.IOUtils.copy(istream, ostream);
         }
 
         XmlFile xml = new XmlFile(Jenkins.XSTREAM2, file);
-        RemotableGoogleCredentials read = (RemotableGoogleCredentials) xml.read();
+        RemotableGoogleCredentials read =
+                (RemotableGoogleCredentials) xml.read();
         DateTime expiration = read.getTokenExpirationTime();
         assertNull("Expiration token should be null", expiration);
-        assertTrue("Deserialized token should be considered as expired", read.isTokenExpired());
+        assertTrue("Deserialized token should be considered as expired",
+                read.isTokenExpired());
     }
 
     private static class Requirement extends GoogleOAuth2ScopeRequirement {

--- a/src/test/resources/com/google/jenkins/plugins/credentials/oauth/jodaDateTimeBroken.xml
+++ b/src/test/resources/com/google/jenkins/plugins/credentials/oauth/jodaDateTimeBroken.xml
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<com.google.jenkins.plugins.credentials.oauth.RemotableGoogleCredentials>
+  <module/>
+  <projectId>myproject</projectId>
+  <username>mattomata</username>
+  <accessToken>&lt;MOCKED&gt;</accessToken>
+  <expiration>
+    <iMillis>1523889095013</iMillis>
+    <iChronology2 class="org.joda.time.chrono.ISOChronology" resolves-to="org.joda.time.chrono.ISOChronology$Stub" serialization="custom">
+      <org.joda.time.chrono.ISOChronology_-Stub>
+        <org.joda.time.tz.CachedDateTimeZone resolves-to="org.joda.time.DateTimeZone$Stub" serialization="custom">
+          <org.joda.time.DateTimeZone_-Stub>
+            <string>Europe/Zurich</string>
+          </org.joda.time.DateTimeZone_-Stub>
+        </org.joda.time.tz.CachedDateTimeZone>
+      </org.joda.time.chrono.ISOChronology_-Stub>
+    </iChronology2>
+  </expiration>
+</com.google.jenkins.plugins.credentials.oauth.RemotableGoogleCredentials>

--- a/src/test/resources/com/google/jenkins/plugins/credentials/oauth/jodaDateTimeNull.xml
+++ b/src/test/resources/com/google/jenkins/plugins/credentials/oauth/jodaDateTimeNull.xml
@@ -1,0 +1,7 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<com.google.jenkins.plugins.credentials.oauth.RemotableGoogleCredentials>
+  <module/>
+  <projectId>myproject</projectId>
+  <username>mattomata</username>
+  <accessToken>&lt;MOCKED&gt;</accessToken>
+</com.google.jenkins.plugins.credentials.oauth.RemotableGoogleCredentials>

--- a/src/test/resources/com/google/jenkins/plugins/credentials/oauth/jodaDateTimeXML.xml
+++ b/src/test/resources/com/google/jenkins/plugins/credentials/oauth/jodaDateTimeXML.xml
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<com.google.jenkins.plugins.credentials.oauth.RemotableGoogleCredentials>
+  <module/>
+  <projectId>myproject</projectId>
+  <username>mattomata</username>
+  <accessToken>&lt;MOCKED&gt;</accessToken>
+  <expiration>
+    <iMillis>1523889095013</iMillis>
+    <iChronology class="org.joda.time.chrono.ISOChronology" resolves-to="org.joda.time.chrono.ISOChronology$Stub" serialization="custom">
+      <org.joda.time.chrono.ISOChronology_-Stub>
+        <org.joda.time.tz.CachedDateTimeZone resolves-to="org.joda.time.DateTimeZone$Stub" serialization="custom">
+          <org.joda.time.DateTimeZone_-Stub>
+            <string>Europe/Zurich</string>
+          </org.joda.time.DateTimeZone_-Stub>
+        </org.joda.time.tz.CachedDateTimeZone>
+      </org.joda.time.chrono.ISOChronology_-Stub>
+    </iChronology>
+  </expiration>
+</com.google.jenkins.plugins.credentials.oauth.RemotableGoogleCredentials>


### PR DESCRIPTION
I have just did some facelifting work during the investigation of https://issues.jenkins-ci.org/browse/JENKINS-50216 . This patch enables PCT runs for the recent versions

I have not signed the Google CLA yet though: https://cla.developers.google.com/ , but #16 states that it's not required anymore. I assume that the copyright requirement in Checkstyle is also outdated then.

- [x] Facelift the plugin
- [x] Add Jenkinsfile
- [x] Add custom serializer logic for JodaTime's `DateTime` class, which replaces the format by a JEP-200-free layout and also adds support of old object deserialization

@reviewbybees @jglick 
