### PR TITLE
Remove CLA Requirement and Remove obsolete PR builder link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,18 +3,6 @@
 We'd love to accept your patches and contributions to this project. There are
 just a few small guidelines you need to follow.
 
-## Contributor License Agreement
-
-Contributions to this project must be accompanied by a Contributor License
-Agreement. You (or your employer) retain the copyright to your contribution,
-this simply gives us permission to use and redistribute your contributions as
-part of the project. Head over to <https://cla.developers.google.com/> to see
-your current agreements on file or to sign a new one.
-
-You generally only need to submit a CLA once, so if you've already submitted one
-(even if it was for a different project), you probably don't need to do it
-again.
-
 ## Code reviews
 
 All submissions, including submissions by project members, require review. We

--- a/README.md
+++ b/README.md
@@ -2,9 +2,7 @@ Jenkins Google OAuth Credentials Plugin
 =====================
 Google-specific implementation of the OAuth Credentials interfaces.
 
-[![Build Status](https://jenkins.ci.cloudbees.com/buildStatus/icon?job=plugins/google-oauth-plugin)](https://jenkins.ci.cloudbees.com/job/plugins/job/google-oauth-plugin/)
-
-Read more: [http://wiki.jenkins-ci.org/display/JENKINS/Google+OAuth+Plugin](http://wiki.jenkins-ci.org/display/JENKINS/Google+OAuth+Plugin)
+Read more: [https://wiki.jenkins.io/display/JENKINS/Google+OAuth+Plugin](https://wiki.jenkins.io/display/JENKINS/Google+OAuth+Plugin)
 
 Development
 ===========


### PR DESCRIPTION
This is a follow-up to the [JENKINS-50216](https://issues.jenkins-ci.org/browse/JENKINS-50216) discussion with @tcnghia in the email threads. According to this discussion, CLA is no longer required.

This PR needs to be integrated in order to unblock JEP-200 maintainers.

CC @reviewbybees @jglick 
