### PR TITLE
[JENKINS-38869] Use SecretBytes to store credentials

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -210,7 +210,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>credentials</artifactId>
-      <version>2.1.5</version>
+      <version>2.1.12</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -210,7 +210,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>credentials</artifactId>
-      <version>1.16.1</version>
+      <version>2.1.5</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/JsonServiceAccountConfig.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/JsonServiceAccountConfig.java
@@ -73,8 +73,12 @@ public class JsonServiceAccountConfig extends ServiceAccountConfig {
 
   /**
    * @param jsonKeyFile uploaded json key file
-   * @param filename previous json key file name. used if jsonKeyFile is not provided.
-   * @param secretJsonKey previous json key file content. used if jsonKeyFile is not provided.
+   * @param filename
+   *     previous json key file name.
+   *     used if jsonKeyFile is not provided.
+   * @param secretJsonKey
+   *     previous json key file content.
+   *     used if jsonKeyFile is not provided.
    * @since 0.7
    */
   @DataBoundConstructor
@@ -91,7 +95,8 @@ public class JsonServiceAccountConfig extends ServiceAccountConfig {
         this.filename = extractFilename(jsonKeyFile.getName());
         this.secretJsonKey = SecretBytes.fromBytes(jsonKeyFile.get());
       } catch (IOException e) {
-          throw new IllegalArgumentException("Failed to read json key from file", e);
+          throw new IllegalArgumentException(
+              "Failed to read json key from file", e);
       }
     } else {
       if (filename == null || secretJsonKey == null) {
@@ -110,14 +115,19 @@ public class JsonServiceAccountConfig extends ServiceAccountConfig {
 
   @Deprecated   // used only for compatibility purpose
   @CheckForNull
-  private static SecretBytes getSecretBytesFromFile(@CheckForNull String filename) {
+  private static SecretBytes getSecretBytesFromFile(
+      @CheckForNull String filename) {
     if (filename == null || filename.isEmpty()) {
       return null;
     }
     try {
-      return SecretBytes.fromBytes(FileUtils.readFileToByteArray(new File(filename)));
+      return SecretBytes.fromBytes(
+          FileUtils.readFileToByteArray(new File(filename)));
     } catch (IOException e) {
-      LOGGER.log(Level.SEVERE, String.format("Failed to read previous key from %s", filename), e);
+      LOGGER.log(
+          Level.SEVERE,
+          String.format("Failed to read previous key from %s", filename),
+          e);
       return null;
     }
   }

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/KeyUtils.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/KeyUtils.java
@@ -23,15 +23,14 @@ import java.nio.charset.StandardCharsets;
 
 import org.apache.commons.io.IOUtils;
 
-import com.cloudbees.plugins.credentials.SecretBytes;
-
 import hudson.util.Secret;
 import jenkins.model.Jenkins;
 
 /**
  * Utility methods for handling key files.
  *
- * @deprecated Consider to use {@link SecretBytes} instead.
+ * @deprecated Consider to use
+ *   {@link com.cloudbees.plugins.credentials.SecretBytes} instead.
  */
 @Deprecated
 public class KeyUtils {

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/KeyUtils.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/KeyUtils.java
@@ -23,12 +23,17 @@ import java.nio.charset.StandardCharsets;
 
 import org.apache.commons.io.IOUtils;
 
+import com.cloudbees.plugins.credentials.SecretBytes;
+
 import hudson.util.Secret;
 import jenkins.model.Jenkins;
 
 /**
  * Utility methods for handling key files.
+ *
+ * @deprecated Consider to use {@link SecretBytes} instead.
  */
+@Deprecated
 public class KeyUtils {
   /**
    * Utility class should never be instantiated.
@@ -38,6 +43,7 @@ public class KeyUtils {
   /**
    * Creates a file with the given prefix/suffix in a standard Google auth
    * directory, and sets the permissions of the file to owner-only read/write.
+   * Note: this doesn't work on Windows.
    *
    * @throws IOException if filesystem interaction fails.
    */
@@ -58,6 +64,7 @@ public class KeyUtils {
 
   /**
    * Sets the permissions of the file to owner-only read/write.
+   * Note: this doesn't work on Windows.
    *
    * @throws IOException if filesystem interaction fails.
    */

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/P12ServiceAccountConfig.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/P12ServiceAccountConfig.java
@@ -170,23 +170,28 @@ public class P12ServiceAccountConfig extends ServiceAccountConfig {
 
   @Override
   public PrivateKey getPrivateKey() {
-    if (secretP12Key != null) {
-      try {
-        KeyStore p12KeyStore = getP12KeyStore();
-        return (PrivateKey) p12KeyStore.getKey(DEFAULT_P12_ALIAS,
-                DEFAULT_P12_SECRET.toCharArray());
-      } catch (IOException e) {
-        LOGGER.log(Level.SEVERE, "Failed to read private key", e);
-      } catch (GeneralSecurityException e) {
-        LOGGER.log(Level.SEVERE, "Failed to read private key", e);
+    try {
+      KeyStore p12KeyStore = getP12KeyStore();
+      if (p12KeyStore == null) {
+        return null;
       }
+      return (PrivateKey) p12KeyStore.getKey(DEFAULT_P12_ALIAS,
+              DEFAULT_P12_SECRET.toCharArray());
+    } catch (IOException e) {
+      LOGGER.log(Level.SEVERE, "Failed to read private key", e);
+    } catch (GeneralSecurityException e) {
+      LOGGER.log(Level.SEVERE, "Failed to read private key", e);
     }
     return null;
   }
 
+  @CheckForNull
   private KeyStore getP12KeyStore() throws KeyStoreException,
           IOException, CertificateException, NoSuchAlgorithmException {
     InputStream in = null;
+    if (secretP12Key == null) {
+      return null;
+    }
     try {
       KeyStore keyStore = KeyStore.getInstance("PKCS12");
       in = new ByteArrayInputStream(secretP12Key.getPlainData());

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/P12ServiceAccountConfig.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/P12ServiceAccountConfig.java
@@ -66,8 +66,12 @@ public class P12ServiceAccountConfig extends ServiceAccountConfig {
   /**
    * @param emailAddress email address
    * @param p12KeyFile uploaded p12 key file
-   * @param filename previous json key file name. used if p12KeyFile is not provided.
-   * @param secretP12Key previous p12 key file content. used if p12KeyFile is not provided.
+   * @param filename
+   *     previous json key file name.
+   *     used if p12KeyFile is not provided.
+   * @param secretP12Key
+   *     previous p12 key file content.
+   *     used if p12KeyFile is not provided.
    * @since 0.7
    */
   @DataBoundConstructor
@@ -95,14 +99,19 @@ public class P12ServiceAccountConfig extends ServiceAccountConfig {
 
   @Deprecated   // used only for compatibility purpose
   @CheckForNull
-  private static SecretBytes getSecretBytesFromFile(@CheckForNull String filename) {
+  private static SecretBytes getSecretBytesFromFile(
+      @CheckForNull String filename) {
     if (filename == null || filename.isEmpty()) {
       return null;
     }
     try {
-      return SecretBytes.fromBytes(FileUtils.readFileToByteArray(new File(filename)));
+      return SecretBytes.fromBytes(
+          FileUtils.readFileToByteArray(new File(filename)));
     } catch (IOException e) {
-      LOGGER.log(Level.SEVERE, String.format("Failed to read previous key from %s", filename), e);
+      LOGGER.log(
+          Level.SEVERE,
+          String.format("Failed to read previous key from %s", filename),
+          e);
       return null;
     }
   }

--- a/src/main/resources/com/google/jenkins/plugins/credentials/oauth/GoogleRobotPrivateKeyCredentials/config.jelly
+++ b/src/main/resources/com/google/jenkins/plugins/credentials/oauth/GoogleRobotPrivateKeyCredentials/config.jelly
@@ -29,17 +29,21 @@
   <j:forEach items="${serviceAccountConfigDescriptors}"
              var="descriptor"
              varStatus="loop">
-    <j:set value="${descriptor == currentServiceAccountConfig.descriptor ? currentServiceAccountConfig : null}"
-           var="serviceAccountConfig"/>
     <f:radioBlock checked="${currentServiceAccountConfig == null ? loop.index == 0 : descriptor == currentServiceAccountConfig.descriptor}"
                   name="serviceAccountConfig"
                   title="${descriptor.displayName}"
                   value="${loop.index}">
-      <st:include from="${descriptor}"
-                  page="${descriptor.configPage}"/>
-      <f:invisibleEntry>
-        <input name="stapler-class" type="hidden" value="${descriptor.clazz.name}"/>
-      </f:invisibleEntry>
+      <f:block><table width="100%"><!-- This is required for radioBlock disables non-wrapped f:invisibleEntry -->
+        <j:scope>
+          <j:set value="${descriptor == currentServiceAccountConfig.descriptor ? currentServiceAccountConfig : null}"
+                 var="instance"/>
+          <st:include from="${descriptor}"
+                      page="${descriptor.configPage}"/>
+          <f:invisibleEntry>
+            <input name="stapler-class" type="hidden" value="${descriptor.clazz.name}"/>
+          </f:invisibleEntry>
+        </j:scope>
+      </table></f:block>
     </f:radioBlock>
   </j:forEach>
 </j:jelly>

--- a/src/main/resources/com/google/jenkins/plugins/credentials/oauth/JsonServiceAccountConfig/config.jelly
+++ b/src/main/resources/com/google/jenkins/plugins/credentials/oauth/JsonServiceAccountConfig/config.jelly
@@ -6,19 +6,17 @@
     <input jsonAware="yes"
            name="jsonKeyFile"
            type="file"/>
-    <j:if test="${serviceAccountConfig.jsonKeyFile != null}">
-      <j:new className="java.io.File"
-             var="jsonKeyFile">
-        <j:arg type="java.lang.String"
-               value="${serviceAccountConfig.jsonKeyFile}"/>
-      </j:new>
+    <j:if test="${instance.secretJsonKey != null}">
       <label class="attach-previous">
         (${%Or reuse previous file:}
-        <code>${jsonKeyFile.name}</code>)
+        <code>${instance.filename}</code>)
       </label>
     </j:if>
   </f:entry>
-  <input name="prevJsonKeyFile"
-         type="hidden"
-         value="${serviceAccountConfig.jsonKeyFile}"/>
+  <f:invisibleEntry>
+    <f:textbox field="filename"/>
+  </f:invisibleEntry>
+  <f:invisibleEntry>
+    <f:textbox field="secretJsonKey"/>
+  </f:invisibleEntry>
 </j:jelly>

--- a/src/main/resources/com/google/jenkins/plugins/credentials/oauth/P12ServiceAccountConfig/config.jelly
+++ b/src/main/resources/com/google/jenkins/plugins/credentials/oauth/P12ServiceAccountConfig/config.jelly
@@ -3,26 +3,24 @@
          xmlns:f="/lib/form">
   <f:entry field="emailAddress"
            title="${%E-Mail Address}">
-    <f:textbox value="${serviceAccountConfig.emailAddress}"/>
+    <f:textbox />
   </f:entry>
   <f:entry field="p12KeyFile"
            title="${%P12 key File}">
     <input jsonAware="yes"
            name="p12KeyFile"
            type="file"/>
-    <j:if test="${serviceAccountConfig.p12KeyFile != null}">
-      <j:new className="java.io.File"
-             var="p12KeyFile">
-        <j:arg type="java.lang.String"
-               value="${serviceAccountConfig.p12KeyFile}"/>
-      </j:new>
+    <j:if test="${instance.secretP12Key != null}">
       <label class="attach-previous">
         (${%Or reuse previous file:}
-        <code>${p12KeyFile.name}</code>)
+        <code>${instance.filename}</code>)
       </label>
     </j:if>
   </f:entry>
-  <input name="prevP12KeyFile"
-         type="hidden"
-         value="${serviceAccountConfig.p12KeyFile}"/>
+  <f:invisibleEntry>
+    <f:textbox field="filename"/>
+  </f:invisibleEntry>
+  <f:invisibleEntry>
+    <f:textbox field="secretP12Key"/>
+  </f:invisibleEntry>
 </j:jelly>

--- a/src/test/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotPrivateKeyCredentialsTest.java
+++ b/src/test/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotPrivateKeyCredentialsTest.java
@@ -119,10 +119,12 @@ public class GoogleRobotPrivateKeyCredentialsTest {
     when(mockFileItem.getName()).thenReturn(jsonKeyPath);
     when(mockFileItem.getInputStream())
             .thenReturn(new FileInputStream(jsonKeyPath));
-    when(mockFileItem.get()).thenReturn(FileUtils.readFileToByteArray(new File(jsonKeyPath)));
+    when(mockFileItem.get())
+            .thenReturn(FileUtils.readFileToByteArray(new File(jsonKeyPath)));
     GoogleRobotPrivateKeyCredentials credentials =
             new GoogleRobotPrivateKeyCredentials(PROJECT_ID,
-                    new JsonServiceAccountConfig(mockFileItem, null, null), module);
+                    new JsonServiceAccountConfig(
+                            mockFileItem, null, null), module);
 
     assertEquals(CredentialsScope.GLOBAL, credentials.getScope());
     assertEquals(SERVICE_ACCOUNT_EMAIL_ADDRESS, credentials.getUsername());
@@ -151,7 +153,8 @@ public class GoogleRobotPrivateKeyCredentialsTest {
     when(mockFileItem.getName()).thenReturn(p12KeyPath);
     when(mockFileItem.getInputStream())
             .thenReturn(new FileInputStream(p12KeyPath));
-    when(mockFileItem.get()).thenReturn(FileUtils.readFileToByteArray(new File(p12KeyPath)));
+    when(mockFileItem.get())
+            .thenReturn(FileUtils.readFileToByteArray(new File(p12KeyPath)));
     P12ServiceAccountConfig keyType = new P12ServiceAccountConfig(
             SERVICE_ACCOUNT_EMAIL_ADDRESS, mockFileItem, null, null);
     GoogleRobotPrivateKeyCredentials credentials =
@@ -378,10 +381,12 @@ public class GoogleRobotPrivateKeyCredentialsTest {
     when(mockFileItem.getName()).thenReturn(jsonKeyPath);
     when(mockFileItem.getInputStream())
             .thenReturn(new FileInputStream(jsonKeyPath));
-    when(mockFileItem.get()).thenReturn(FileUtils.readFileToByteArray(new File(jsonKeyPath)));
+    when(mockFileItem.get())
+            .thenReturn(FileUtils.readFileToByteArray(new File(jsonKeyPath)));
     GoogleRobotPrivateKeyCredentials credentials =
             new GoogleRobotPrivateKeyCredentials(PROJECT_ID,
-                    new JsonServiceAccountConfig(mockFileItem, null, null), null);
+                    new JsonServiceAccountConfig(
+                            mockFileItem, null, null), null);
 
     SystemCredentialsProvider.getInstance().getCredentials().add(credentials);
 

--- a/src/test/java/com/google/jenkins/plugins/credentials/oauth/JsonServiceAccountConfigTest.java
+++ b/src/test/java/com/google/jenkins/plugins/credentials/oauth/JsonServiceAccountConfigTest.java
@@ -107,7 +107,8 @@ public class JsonServiceAccountConfigTest {
   }
 
   @Test
-  public void testCreateJsonKeyTypeWithPrevJsonKeyFileForCompatibility() throws Exception {
+  public void testCreateJsonKeyTypeWithPrevJsonKeyFileForCompatibility()
+      throws Exception {
     JsonServiceAccountConfig jsonServiceAccountConfig =
         new JsonServiceAccountConfig(null, jsonKeyPath);
 
@@ -118,7 +119,8 @@ public class JsonServiceAccountConfigTest {
 
   @Test
   public void testCreateJsonKeyTypeWithPrevJsonKeyFile() throws Exception {
-    SecretBytes prev = SecretBytes.fromBytes(FileUtils.readFileToByteArray(new File(jsonKeyPath)));
+    SecretBytes prev = SecretBytes
+            .fromBytes(FileUtils.readFileToByteArray(new File(jsonKeyPath)));
     JsonServiceAccountConfig jsonServiceAccountConfig =
         new JsonServiceAccountConfig(null, jsonKeyPath, prev);
 

--- a/src/test/java/com/google/jenkins/plugins/credentials/oauth/JsonServiceAccountConfigTest.java
+++ b/src/test/java/com/google/jenkins/plugins/credentials/oauth/JsonServiceAccountConfigTest.java
@@ -31,7 +31,6 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -48,8 +47,6 @@ public class JsonServiceAccountConfigTest {
   private static String jsonKeyPath;
   @Rule
   public JenkinsRule jenkinsRule = new JenkinsRule();
-  @Rule
-  public final ExpectedException exception = ExpectedException.none();
   @Mock
   private FileItem mockFileItem;
 
@@ -82,15 +79,22 @@ public class JsonServiceAccountConfigTest {
 
   @Test
   public void testCreateJsonKeyTypeWithNullParameters() throws Exception {
-    exception.expect(IllegalArgumentException.class);
-    new JsonServiceAccountConfig(null, null, null);
+    JsonServiceAccountConfig jsonServiceAccountConfig =
+        new JsonServiceAccountConfig(null, null, null);
+
+    assertNull(jsonServiceAccountConfig.getAccountId());
+    assertNull(jsonServiceAccountConfig.getPrivateKey());
   }
 
   @Test
   public void testCreateJsonKeyTypeWithEmptyJsonKeyFile() throws Exception {
     when(mockFileItem.getSize()).thenReturn(0L);
-    exception.expect(IllegalArgumentException.class);
-    new JsonServiceAccountConfig(mockFileItem, null, null);
+    JsonServiceAccountConfig jsonKeyType = new JsonServiceAccountConfig
+        (mockFileItem, null);
+
+    assertNull(jsonKeyType.getJsonKeyFile());
+    assertNull(jsonKeyType.getAccountId());
+    assertNull(jsonKeyType.getPrivateKey());
   }
 
   @Test
@@ -102,8 +106,11 @@ public class JsonServiceAccountConfigTest {
         .thenReturn(new ByteArrayInputStream(bytes));
     when(mockFileItem.get())
         .thenReturn(bytes);
-    exception.expect(IllegalArgumentException.class);
-    new JsonServiceAccountConfig(mockFileItem, null, null);
+    JsonServiceAccountConfig jsonServiceAccountConfig =
+        new JsonServiceAccountConfig(mockFileItem, null, null);
+
+    assertNull(jsonServiceAccountConfig.getAccountId());
+    assertNull(jsonServiceAccountConfig.getPrivateKey());
   }
 
   @Test
@@ -132,7 +139,6 @@ public class JsonServiceAccountConfigTest {
   @Test
   public void testCreateJsonKeyTypeWithEmptyPrevJsonKeyFile() throws Exception {
     SecretBytes prev = SecretBytes.fromString("");
-    exception.expect(IllegalArgumentException.class);
     JsonServiceAccountConfig jsonServiceAccountConfig =
         new JsonServiceAccountConfig(null, "", prev);
 
@@ -143,9 +149,12 @@ public class JsonServiceAccountConfigTest {
   @Test
   public void testCreateJsonKeyTypeWithInvalidPrevJsonKeyFile()
       throws Exception {
-    exception.expect(IllegalArgumentException.class);
     String invalidPrevJsonKeyFile = "invalidPrevJsonKeyFile.json";
-    new JsonServiceAccountConfig(null, invalidPrevJsonKeyFile, null);
+    JsonServiceAccountConfig jsonServiceAccountConfig =
+        new JsonServiceAccountConfig(null, invalidPrevJsonKeyFile, null);
+
+    assertNull(jsonServiceAccountConfig.getAccountId());
+    assertNull(jsonServiceAccountConfig.getPrivateKey());
   }
 
   @Test

--- a/src/test/java/com/google/jenkins/plugins/credentials/oauth/P12ServiceAccountConfigTest.java
+++ b/src/test/java/com/google/jenkins/plugins/credentials/oauth/P12ServiceAccountConfigTest.java
@@ -30,7 +30,6 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.WithoutJenkins;
 import org.mockito.Mock;
@@ -48,8 +47,6 @@ public class P12ServiceAccountConfigTest {
   private static String p12KeyPath;
   @Rule
   public JenkinsRule jenkinsRule = new JenkinsRule();
-  @Rule
-  public final ExpectedException exception = ExpectedException.none();
   @Mock
   private FileItem mockFileItem;
 
@@ -93,20 +90,27 @@ public class P12ServiceAccountConfigTest {
   @Test
   @WithoutJenkins
   public void testCreateWithNullP12KeyFile() throws Exception {
-    exception.expect(IllegalArgumentException.class);
-    new P12ServiceAccountConfig(SERVICE_ACCOUNT_EMAIL_ADDRESS, null,
-        null, null);
+    P12ServiceAccountConfig p12ServiceAccountConfig =
+        new P12ServiceAccountConfig(SERVICE_ACCOUNT_EMAIL_ADDRESS, null,
+            null, null);
+
+    assertEquals(SERVICE_ACCOUNT_EMAIL_ADDRESS,
+        p12ServiceAccountConfig.getAccountId());
+    assertNull(p12ServiceAccountConfig.getPrivateKey());
   }
 
   @Test
   @WithoutJenkins
   public void testCreateWithEmptyP12KeyFile() throws Exception {
-    exception.expect(IllegalArgumentException.class);
     when(mockFileItem.getSize()).thenReturn(0L);
     when(mockFileItem.get()).thenReturn(new byte[]{});
-    exception.expect(IllegalArgumentException.class);
-    new P12ServiceAccountConfig(SERVICE_ACCOUNT_EMAIL_ADDRESS,
-        mockFileItem, null, null);
+    P12ServiceAccountConfig p12ServiceAccountConfig =
+        new P12ServiceAccountConfig(SERVICE_ACCOUNT_EMAIL_ADDRESS,
+            mockFileItem, null, null);
+
+    assertEquals(SERVICE_ACCOUNT_EMAIL_ADDRESS,
+            p12ServiceAccountConfig.getAccountId());
+    assertNull(p12ServiceAccountConfig.getPrivateKey());
   }
 
   @Test
@@ -164,9 +168,13 @@ public class P12ServiceAccountConfigTest {
   @Test
   @WithoutJenkins
   public void testCreateWithInvalidPrevP12KeyFile() throws Exception {
-    exception.expect(IllegalArgumentException.class);
-    new P12ServiceAccountConfig(SERVICE_ACCOUNT_EMAIL_ADDRESS, null,
-        "invalidPrevP12KeyFile.p12", null);
+    P12ServiceAccountConfig p12ServiceAccountConfig =
+        new P12ServiceAccountConfig(SERVICE_ACCOUNT_EMAIL_ADDRESS, null,
+            "invalidPrevP12KeyFile.p12", null);
+
+    assertEquals(SERVICE_ACCOUNT_EMAIL_ADDRESS,
+        p12ServiceAccountConfig.getAccountId());
+    assertNull(p12ServiceAccountConfig.getPrivateKey());
   }
 
   @Test

--- a/src/test/java/com/google/jenkins/plugins/credentials/oauth/P12ServiceAccountConfigTest.java
+++ b/src/test/java/com/google/jenkins/plugins/credentials/oauth/P12ServiceAccountConfigTest.java
@@ -81,7 +81,8 @@ public class P12ServiceAccountConfigTest {
 
   @Test
   public void testCreateWithNullAccountId() throws Exception {
-    SecretBytes prev = SecretBytes.fromBytes(FileUtils.readFileToByteArray(new File(p12KeyPath)));
+    SecretBytes prev = SecretBytes.fromBytes(
+        FileUtils.readFileToByteArray(new File(p12KeyPath)));
     P12ServiceAccountConfig p12ServiceAccountConfig =
         new P12ServiceAccountConfig(null, null, p12KeyPath, prev);
 
@@ -137,7 +138,8 @@ public class P12ServiceAccountConfigTest {
 
   @Test
   public void testCreateWithPrevP12KeyFile() throws Exception {
-    SecretBytes prev = SecretBytes.fromBytes(FileUtils.readFileToByteArray(new File(p12KeyPath)));
+    SecretBytes prev = SecretBytes.fromBytes(
+            FileUtils.readFileToByteArray(new File(p12KeyPath)));
     P12ServiceAccountConfig p12ServiceAccountConfig =
         new P12ServiceAccountConfig(SERVICE_ACCOUNT_EMAIL_ADDRESS, null,
             p12KeyPath, prev);

--- a/src/test/java/com/google/jenkins/plugins/credentials/oauth/P12ServiceAccountConfigTest.java
+++ b/src/test/java/com/google/jenkins/plugins/credentials/oauth/P12ServiceAccountConfigTest.java
@@ -18,23 +18,25 @@ package com.google.jenkins.plugins.credentials.oauth;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.io.FileInputStream;
 import java.security.KeyPair;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
 
 import org.apache.commons.fileupload.FileItem;
+import org.apache.commons.io.FileUtils;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.WithoutJenkins;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+
+import com.cloudbees.plugins.credentials.SecretBytes;
 
 /**
  * Tests for {@link P12ServiceAccountConfig}.
@@ -46,6 +48,8 @@ public class P12ServiceAccountConfigTest {
   private static String p12KeyPath;
   @Rule
   public JenkinsRule jenkinsRule = new JenkinsRule();
+  @Rule
+  public final ExpectedException exception = ExpectedException.none();
   @Mock
   private FileItem mockFileItem;
 
@@ -63,11 +67,12 @@ public class P12ServiceAccountConfigTest {
   @Test
   public void testCreateWithNewP12KeyFile() throws Exception {
     when(mockFileItem.getSize()).thenReturn(1L);
-    when(mockFileItem.getInputStream())
-        .thenReturn(new FileInputStream(p12KeyPath));
+    when(mockFileItem.getName()).thenReturn(p12KeyPath);
+    when(mockFileItem.get())
+        .thenReturn(FileUtils.readFileToByteArray(new File(p12KeyPath)));
     P12ServiceAccountConfig p12ServiceAccountConfig =
         new P12ServiceAccountConfig(SERVICE_ACCOUNT_EMAIL_ADDRESS,
-            mockFileItem, null);
+            mockFileItem, null, null);
 
     assertEquals(SERVICE_ACCOUNT_EMAIL_ADDRESS, p12ServiceAccountConfig
         .getAccountId());
@@ -75,10 +80,10 @@ public class P12ServiceAccountConfigTest {
   }
 
   @Test
-  @WithoutJenkins
   public void testCreateWithNullAccountId() throws Exception {
+    SecretBytes prev = SecretBytes.fromBytes(FileUtils.readFileToByteArray(new File(p12KeyPath)));
     P12ServiceAccountConfig p12ServiceAccountConfig =
-        new P12ServiceAccountConfig(null, null, p12KeyPath);
+        new P12ServiceAccountConfig(null, null, p12KeyPath, prev);
 
     assertNull(p12ServiceAccountConfig.getAccountId());
     assertEquals(keyPair.getPrivate(), p12ServiceAccountConfig.getPrivateKey());
@@ -87,37 +92,32 @@ public class P12ServiceAccountConfigTest {
   @Test
   @WithoutJenkins
   public void testCreateWithNullP12KeyFile() throws Exception {
-    P12ServiceAccountConfig p12ServiceAccountConfig =
-        new P12ServiceAccountConfig(SERVICE_ACCOUNT_EMAIL_ADDRESS, null,
-            null);
-
-    assertEquals(SERVICE_ACCOUNT_EMAIL_ADDRESS,
-        p12ServiceAccountConfig.getAccountId());
-    assertNull(p12ServiceAccountConfig.getPrivateKey());
+    exception.expect(IllegalArgumentException.class);
+    new P12ServiceAccountConfig(SERVICE_ACCOUNT_EMAIL_ADDRESS, null,
+        null, null);
   }
 
   @Test
   @WithoutJenkins
   public void testCreateWithEmptyP12KeyFile() throws Exception {
+    exception.expect(IllegalArgumentException.class);
     when(mockFileItem.getSize()).thenReturn(0L);
-    P12ServiceAccountConfig p12ServiceAccountConfig =
-        new P12ServiceAccountConfig(SERVICE_ACCOUNT_EMAIL_ADDRESS,
-            mockFileItem, null);
-
-    assertEquals(SERVICE_ACCOUNT_EMAIL_ADDRESS,
-            p12ServiceAccountConfig.getAccountId());
-    assertNull(p12ServiceAccountConfig.getPrivateKey());
+    when(mockFileItem.get()).thenReturn(new byte[]{});
+    exception.expect(IllegalArgumentException.class);
+    new P12ServiceAccountConfig(SERVICE_ACCOUNT_EMAIL_ADDRESS,
+        mockFileItem, null, null);
   }
 
   @Test
   public void testCreateWithInvalidP12KeyFile() throws Exception {
     byte[] bytes = "invalidP12KeyFile".getBytes();
     when(mockFileItem.getSize()).thenReturn((long) bytes.length);
-    when(mockFileItem.getInputStream())
-        .thenReturn(new ByteArrayInputStream(bytes));
+    when(mockFileItem.getName()).thenReturn("invalidP12KeyFile");
+    when(mockFileItem.get())
+        .thenReturn(bytes);
     P12ServiceAccountConfig p12ServiceAccountConfig =
         new P12ServiceAccountConfig(SERVICE_ACCOUNT_EMAIL_ADDRESS,
-            mockFileItem, null);
+            mockFileItem, null, null);
 
     assertEquals(SERVICE_ACCOUNT_EMAIL_ADDRESS,
         p12ServiceAccountConfig.getAccountId());
@@ -125,8 +125,7 @@ public class P12ServiceAccountConfigTest {
   }
 
   @Test
-  @WithoutJenkins
-  public void testCreateWithPrevP12KeyFile() throws Exception {
+  public void testCreateWithPrevP12KeyFileForCompatibility() throws Exception {
     P12ServiceAccountConfig p12ServiceAccountConfig =
         new P12ServiceAccountConfig(SERVICE_ACCOUNT_EMAIL_ADDRESS, null,
             p12KeyPath);
@@ -137,11 +136,23 @@ public class P12ServiceAccountConfigTest {
   }
 
   @Test
-  @WithoutJenkins
-  public void testCreateWithEmptyPrevP12KeyFile() throws Exception {
+  public void testCreateWithPrevP12KeyFile() throws Exception {
+    SecretBytes prev = SecretBytes.fromBytes(FileUtils.readFileToByteArray(new File(p12KeyPath)));
     P12ServiceAccountConfig p12ServiceAccountConfig =
         new P12ServiceAccountConfig(SERVICE_ACCOUNT_EMAIL_ADDRESS, null,
-            "");
+            p12KeyPath, prev);
+
+    assertEquals(SERVICE_ACCOUNT_EMAIL_ADDRESS,
+        p12ServiceAccountConfig.getAccountId());
+    assertEquals(keyPair.getPrivate(), p12ServiceAccountConfig.getPrivateKey());
+  }
+
+  @Test
+  public void testCreateWithEmptyPrevP12KeyFile() throws Exception {
+    SecretBytes prev = SecretBytes.fromString("");
+    P12ServiceAccountConfig p12ServiceAccountConfig =
+        new P12ServiceAccountConfig(SERVICE_ACCOUNT_EMAIL_ADDRESS, null,
+            "", prev);
 
     assertEquals(SERVICE_ACCOUNT_EMAIL_ADDRESS,
         p12ServiceAccountConfig.getAccountId());
@@ -151,23 +162,20 @@ public class P12ServiceAccountConfigTest {
   @Test
   @WithoutJenkins
   public void testCreateWithInvalidPrevP12KeyFile() throws Exception {
-    P12ServiceAccountConfig p12ServiceAccountConfig =
-        new P12ServiceAccountConfig(SERVICE_ACCOUNT_EMAIL_ADDRESS, null,
-            "invalidPrevP12KeyFile.p12");
-
-    assertEquals(SERVICE_ACCOUNT_EMAIL_ADDRESS,
-        p12ServiceAccountConfig.getAccountId());
-    assertNull(p12ServiceAccountConfig.getPrivateKey());
+    exception.expect(IllegalArgumentException.class);
+    new P12ServiceAccountConfig(SERVICE_ACCOUNT_EMAIL_ADDRESS, null,
+        "invalidPrevP12KeyFile.p12", null);
   }
 
   @Test
   public void testSerialization() throws Exception {
     when(mockFileItem.getSize()).thenReturn(1L);
-    when(mockFileItem.getInputStream())
-        .thenReturn(new FileInputStream(p12KeyPath));
+    when(mockFileItem.getName()).thenReturn(p12KeyPath);
+    when(mockFileItem.get())
+        .thenReturn(FileUtils.readFileToByteArray(new File(p12KeyPath)));
     P12ServiceAccountConfig p12ServiceAccountConfig =
         new P12ServiceAccountConfig(SERVICE_ACCOUNT_EMAIL_ADDRESS,
-            mockFileItem, null);
+            mockFileItem, null, null);
 
     ByteArrayOutputStream out = new ByteArrayOutputStream();
     SerializationUtil.serialize(p12ServiceAccountConfig, out);
@@ -175,7 +183,6 @@ public class P12ServiceAccountConfigTest {
     P12ServiceAccountConfig deserializedP12KeyType =
         SerializationUtil.deserialize(P12ServiceAccountConfig.class, in);
 
-    assertTrue(new File(deserializedP12KeyType.getP12KeyFile()).exists());
     assertEquals(SERVICE_ACCOUNT_EMAIL_ADDRESS,
         deserializedP12KeyType.getAccountId());
     assertEquals(keyPair.getPrivate(), deserializedP12KeyType.getPrivateKey());

--- a/src/test/java/com/google/jenkins/plugins/credentials/oauth/RemotableGoogleCredentialsTest.java
+++ b/src/test/java/com/google/jenkins/plugins/credentials/oauth/RemotableGoogleCredentialsTest.java
@@ -105,15 +105,14 @@ public class RemotableGoogleCredentialsTest {
         closeTo(EXPIRATION_SECONDS, 2));
   }
 
-  @Test(expected = UnsupportedOperationException.class)
-  public void testUnsupportedName() throws Exception {
+  public void testName() throws Exception {
     fakeCredential.setAccessToken(ACCESS_TOKEN);
     fakeCredential.setExpiresInSeconds(EXPIRATION_SECONDS);
 
     GoogleRobotCredentials credentials =
         new RemotableGoogleCredentials(mockCredentials, testConsumer, module);
 
-    CredentialsNameProvider.name(credentials);
+    assertEquals("RemotableGoogleCredentials", CredentialsNameProvider.name(credentials));
   }
 
 

--- a/src/test/java/com/google/jenkins/plugins/credentials/oauth/RemotableGoogleCredentialsTest.java
+++ b/src/test/java/com/google/jenkins/plugins/credentials/oauth/RemotableGoogleCredentialsTest.java
@@ -112,7 +112,8 @@ public class RemotableGoogleCredentialsTest {
     GoogleRobotCredentials credentials =
         new RemotableGoogleCredentials(mockCredentials, testConsumer, module);
 
-    assertEquals("RemotableGoogleCredentials", CredentialsNameProvider.name(credentials));
+    assertEquals("RemotableGoogleCredentials",
+        CredentialsNameProvider.name(credentials));
   }
 
 


### PR DESCRIPTION
[JENKINS-38869](https://issues.jenkins-ci.org/browse/JENKINS-38869)

As pointed in the above issue ticket and in #13, key files failed to be saved on Windows.
It is caused for `File#setReadable(false, false)` returns `false` on Windows, supposed that Windows doesn't support the state "no one can read that file".

Though it might be resolved using ACL features of nio (`AclFileAttributeView`) on Windows,
I think it would be better to resolve this issue in "Jenkins credential-plugin way", that is, by using [`SecretBytes`](https://javadoc.jenkins.io/plugin/credentials/com/cloudbees/plugins/credentials/SecretBytes.html)
`SecretBytes` is provided by credentials-plugin, and used in [`FileCredentials` in plain-credentials-plugin](https://github.com/jenkinsci/plain-credentials-plugin/blob/master/src/main/java/org/jenkinsci/plugins/plaincredentials/impl/FileCredentialsImpl.java).

This change stores credentials using `SecretBytes`, that results storing to `credentials.xml` in JENKINS_HOME.
