### PR TITLE
Add missing license headers, update existing licenses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+<!--
+  Copyright 2019 Google LLC
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
 # Changelog
 All notable changes to this project will be documented in this file.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,18 @@
+<!--
+  Copyright 2019 Google LLC
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
 # How to contribute
 
 We'd love to accept your patches and contributions to this project. There are

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 <!--
-  Copyright 2019 Google LLC
+  Copyright 2017 Google LLC
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@ Apache License
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 Apache License
                            Version 2.0, January 2004
-                        https://www.apache.org/licenses/
+                        http://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@ Apache License
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       https://www.apache.org/licenses/LICENSE-2.0
+       http://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-     http://www.apache.org/licenses/LICENSE-2.0
+     https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/README.md
+++ b/README.md
@@ -1,3 +1,18 @@
+<!--
+Copyright 2019 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
 Jenkins Google OAuth Credentials Plugin
 =====================
 The Google OAuth plugin provides a Google-specific implementation of the OAuth Credentials interfaces.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!--
-Copyright 2013-2019 Google LLC
+Copyright 2013 Google LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!--
-Copyright 2019 Google LLC
+Copyright 2013-2019 Google LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/checkstyleJavaHeader
+++ b/checkstyleJavaHeader
@@ -5,7 +5,7 @@
 ^ \* you may not use this file except in compliance with the License\.$
 ^ \* You may obtain a copy of the License at$
 ^ \*$
-^ \*     http://www\.apache\.org/licenses/LICENSE-2\.0$
+^ \*     https://www\.apache\.org/licenses/LICENSE-2\.0$
 ^ \*$
 ^ \* Unless required by applicable law or agreed to in writing, software$
 ^ \* distributed under the License is distributed on an \"AS IS\" BASIS,$

--- a/checkstyleJavaHeader
+++ b/checkstyleJavaHeader
@@ -1,5 +1,5 @@
 ^/\*$
-^ \* Copyright 201(3|4|5|6|7|8) .*$
+^ \* Copyright 201(9) .*$
 ^ \*$
 ^ \* Licensed under the Apache License, Version 2\.0 \(the \"License\"\);$
 ^ \* you may not use this file except in compliance with the License\.$

--- a/checkstyleJavaHeader
+++ b/checkstyleJavaHeader
@@ -1,5 +1,5 @@
 ^/\*$
-^ \* Copyright 201(9) .*$
+^ \* Copyright 201\d(-20\d\d)? Google LLC*$
 ^ \*$
 ^ \* Licensed under the Apache License, Version 2\.0 \(the \"License\"\);$
 ^ \* you may not use this file except in compliance with the License\.$

--- a/checkstyleJavaHeader
+++ b/checkstyleJavaHeader
@@ -1,5 +1,5 @@
 ^/\*$
-^ \* Copyright 201\d(-20\d\d)? Google LLC*$
+^ \* Copyright 20\d\d Google LLC*$
 ^ \*$
 ^ \* Licensed under the Apache License, Version 2\.0 \(the \"License\"\);$
 ^ \* you may not use this file except in compliance with the License\.$

--- a/docs/home.md
+++ b/docs/home.md
@@ -1,3 +1,16 @@
+<!--
+ Copyright 2019 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ compliance with the License. You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ implied. See the License for the specific language governing permissions and limitations under the
+ License.
+-->
 # Google OAuth Plugin Documentation
 
 This plugin implements the OAuth Credentials interfaces for surfacing [Google Service Accounts](https://cloud.google.com/iam/docs/understanding-service-accounts) to Jenkins. This plugin allows for the registration of Google Service Account Credentials with the Jenkins master, which can be used to interact with Google APIs.

--- a/docs/source_build_installation.md
+++ b/docs/source_build_installation.md
@@ -1,3 +1,16 @@
+<!--
+ Copyright 2019 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ compliance with the License. You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ implied. See the License for the specific language governing permissions and limitations under the
+ License.
+-->
 # Plugin Source Build Installation
 
 1. Clone the plugin and enter the directory:

--- a/findbugs-exclude.xml
+++ b/findbugs-exclude.xml
@@ -6,7 +6,7 @@
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,

--- a/findbugs-exclude.xml
+++ b/findbugs-exclude.xml
@@ -1,4 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright 2019 Google LLC
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
 <FindBugsFilter>
   <Match>
     <Bug pattern="DM_STRING_CTOR"/>

--- a/findbugs-exclude.xml
+++ b/findbugs-exclude.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright 2014-2019 Google LLC
+  Copyright 2014 Google LLC
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/findbugs-exclude.xml
+++ b/findbugs-exclude.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright 2019 Google LLC
+  Copyright 2014-2019 Google LLC
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,5 @@
 <!--
- Copyright 2013-2019 Google LLC
+ Copyright 2013 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,5 @@
 <!--
- Copyright 2019 Google LLC
+ Copyright 2013-2019 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/pom.xml
+++ b/pom.xml
@@ -1,11 +1,11 @@
 <!--
- Copyright 2013 Google Inc. All Rights Reserved.
+ Copyright 2019 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
  You may obtain a copy of the License at
 
-     http://www.apache.org/licenses/LICENSE-2.0
+     https://www.apache.org/licenses/LICENSE-2.0
 
  Unless required by applicable law or agreed to in writing, software
  distributed under the License is distributed on an "AS IS" BASIS,
@@ -36,7 +36,7 @@
   <licenses>
     <license>
       <name>The Apache V2 License</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/AbstractGoogleRobotCredentialsDescriptor.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/AbstractGoogleRobotCredentialsDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 Google LLC
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/AbstractGoogleRobotCredentialsDescriptor.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/AbstractGoogleRobotCredentialsDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google LLC
+ * Copyright 2013-2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/AbstractGoogleRobotCredentialsDescriptor.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/AbstractGoogleRobotCredentialsDescriptor.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2013 Google Inc. All Rights Reserved.
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleOAuth2Credentials.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleOAuth2Credentials.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 Google LLC
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleOAuth2Credentials.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleOAuth2Credentials.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google LLC
+ * Copyright 2013-2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleOAuth2Credentials.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleOAuth2Credentials.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2013 Google Inc. All Rights Reserved.
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleOAuth2ScopeRequirement.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleOAuth2ScopeRequirement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 Google LLC
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleOAuth2ScopeRequirement.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleOAuth2ScopeRequirement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google LLC
+ * Copyright 2013-2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleOAuth2ScopeRequirement.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleOAuth2ScopeRequirement.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2013 Google Inc. All Rights Reserved.
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleOAuth2ScopeSpecification.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleOAuth2ScopeSpecification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 Google LLC
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleOAuth2ScopeSpecification.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleOAuth2ScopeSpecification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google LLC
+ * Copyright 2013-2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleOAuth2ScopeSpecification.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleOAuth2ScopeSpecification.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2013 Google Inc. All Rights Reserved.
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotCredentials.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotCredentials.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 Google LLC
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotCredentials.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotCredentials.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google LLC
+ * Copyright 2013-2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotCredentials.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotCredentials.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2013 Google Inc. All Rights Reserved.
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotCredentialsModule.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotCredentialsModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 Google LLC
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotCredentialsModule.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotCredentialsModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google LLC
+ * Copyright 2013-2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotCredentialsModule.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotCredentialsModule.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2013 Google Inc. All Rights Reserved.
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotMetadataCredentials.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotMetadataCredentials.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 Google LLC
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotMetadataCredentials.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotMetadataCredentials.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google LLC
+ * Copyright 2013-2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotMetadataCredentials.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotMetadataCredentials.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2013 Google Inc. All Rights Reserved.
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotMetadataCredentialsModule.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotMetadataCredentialsModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 Google LLC
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotMetadataCredentialsModule.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotMetadataCredentialsModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google LLC
+ * Copyright 2013-2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotMetadataCredentialsModule.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotMetadataCredentialsModule.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2013 Google Inc. All Rights Reserved.
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotNameProvider.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotNameProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 Google LLC
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotNameProvider.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotNameProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google LLC
+ * Copyright 2013-2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotNameProvider.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotNameProvider.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2013 Google Inc. All Rights Reserved.
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotPrivateKeyCredentials.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotPrivateKeyCredentials.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 Google LLC
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotPrivateKeyCredentials.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotPrivateKeyCredentials.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google LLC
+ * Copyright 2013-2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotPrivateKeyCredentials.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotPrivateKeyCredentials.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2013 Google Inc. All Rights Reserved.
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/JsonKey.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/JsonKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google LLC
+ * Copyright 2014-2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/JsonKey.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/JsonKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 Google LLC
+ * Copyright 2014 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/JsonKey.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/JsonKey.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2013 Google Inc. All Rights Reserved.
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/JsonServiceAccountConfig.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/JsonServiceAccountConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google LLC
+ * Copyright 2014-2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/JsonServiceAccountConfig.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/JsonServiceAccountConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 Google LLC
+ * Copyright 2014 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/JsonServiceAccountConfig.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/JsonServiceAccountConfig.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2013 Google Inc. All Rights Reserved.
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/KeyUtils.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/KeyUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/KeyUtils.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/KeyUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 Google LLC
+ * Copyright 2015 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/KeyUtils.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/KeyUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Google Inc. All Rights Reserved.
+ * Copyright 2015-2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/LegacyJsonKey.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/LegacyJsonKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 Google LLC
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/LegacyJsonKey.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/LegacyJsonKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google LLC
+ * Copyright 2013-2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/LegacyJsonKey.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/LegacyJsonKey.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2013 Google Inc. All Rights Reserved.
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/P12ServiceAccountConfig.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/P12ServiceAccountConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google LLC
+ * Copyright 2014-2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/P12ServiceAccountConfig.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/P12ServiceAccountConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 Google LLC
+ * Copyright 2014 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/P12ServiceAccountConfig.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/P12ServiceAccountConfig.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2013 Google Inc. All Rights Reserved.
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/RemotableGoogleCredentials.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/RemotableGoogleCredentials.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 Google LLC
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/RemotableGoogleCredentials.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/RemotableGoogleCredentials.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google LLC
+ * Copyright 2013-2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/RemotableGoogleCredentials.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/RemotableGoogleCredentials.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2013 Google Inc. All Rights Reserved.
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/ServiceAccountConfig.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/ServiceAccountConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google LLC
+ * Copyright 2014-2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/ServiceAccountConfig.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/ServiceAccountConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 Google LLC
+ * Copyright 2014 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/ServiceAccountConfig.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/ServiceAccountConfig.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2013 Google Inc. All Rights Reserved.
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/package-info.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 Google LLC
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/package-info.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google LLC
+ * Copyright 2013-2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/package-info.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/package-info.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2013 Google Inc. All Rights Reserved.
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/google/jenkins/plugins/util/ConflictException.java
+++ b/src/main/java/com/google/jenkins/plugins/util/ConflictException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 Google LLC
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/google/jenkins/plugins/util/ConflictException.java
+++ b/src/main/java/com/google/jenkins/plugins/util/ConflictException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google LLC
+ * Copyright 2013-2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/google/jenkins/plugins/util/ConflictException.java
+++ b/src/main/java/com/google/jenkins/plugins/util/ConflictException.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2013 Google Inc. All Rights Reserved.
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/google/jenkins/plugins/util/Executor.java
+++ b/src/main/java/com/google/jenkins/plugins/util/Executor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 Google LLC
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/google/jenkins/plugins/util/Executor.java
+++ b/src/main/java/com/google/jenkins/plugins/util/Executor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google LLC
+ * Copyright 2013-2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/google/jenkins/plugins/util/Executor.java
+++ b/src/main/java/com/google/jenkins/plugins/util/Executor.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2013 Google Inc. All Rights Reserved.
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/google/jenkins/plugins/util/ExecutorException.java
+++ b/src/main/java/com/google/jenkins/plugins/util/ExecutorException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 Google LLC
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/google/jenkins/plugins/util/ExecutorException.java
+++ b/src/main/java/com/google/jenkins/plugins/util/ExecutorException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google LLC
+ * Copyright 2013-2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/google/jenkins/plugins/util/ExecutorException.java
+++ b/src/main/java/com/google/jenkins/plugins/util/ExecutorException.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2013 Google Inc. All Rights Reserved.
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/google/jenkins/plugins/util/ForbiddenException.java
+++ b/src/main/java/com/google/jenkins/plugins/util/ForbiddenException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 Google LLC
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/google/jenkins/plugins/util/ForbiddenException.java
+++ b/src/main/java/com/google/jenkins/plugins/util/ForbiddenException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google LLC
+ * Copyright 2013-2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/google/jenkins/plugins/util/ForbiddenException.java
+++ b/src/main/java/com/google/jenkins/plugins/util/ForbiddenException.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2013 Google Inc. All Rights Reserved.
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/google/jenkins/plugins/util/MaxRetryExceededException.java
+++ b/src/main/java/com/google/jenkins/plugins/util/MaxRetryExceededException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 Google LLC
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/google/jenkins/plugins/util/MaxRetryExceededException.java
+++ b/src/main/java/com/google/jenkins/plugins/util/MaxRetryExceededException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google LLC
+ * Copyright 2013-2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/google/jenkins/plugins/util/MaxRetryExceededException.java
+++ b/src/main/java/com/google/jenkins/plugins/util/MaxRetryExceededException.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2013 Google Inc. All Rights Reserved.
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/google/jenkins/plugins/util/MetadataReader.java
+++ b/src/main/java/com/google/jenkins/plugins/util/MetadataReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 Google LLC
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/google/jenkins/plugins/util/MetadataReader.java
+++ b/src/main/java/com/google/jenkins/plugins/util/MetadataReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google LLC
+ * Copyright 2013-2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/google/jenkins/plugins/util/MetadataReader.java
+++ b/src/main/java/com/google/jenkins/plugins/util/MetadataReader.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2013 Google Inc. All Rights Reserved.
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/google/jenkins/plugins/util/MockExecutor.java
+++ b/src/main/java/com/google/jenkins/plugins/util/MockExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 Google LLC
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/google/jenkins/plugins/util/MockExecutor.java
+++ b/src/main/java/com/google/jenkins/plugins/util/MockExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google LLC
+ * Copyright 2013-2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/google/jenkins/plugins/util/MockExecutor.java
+++ b/src/main/java/com/google/jenkins/plugins/util/MockExecutor.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2013 Google Inc. All Rights Reserved.
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/google/jenkins/plugins/util/NameValuePair.java
+++ b/src/main/java/com/google/jenkins/plugins/util/NameValuePair.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 Google LLC
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/google/jenkins/plugins/util/NameValuePair.java
+++ b/src/main/java/com/google/jenkins/plugins/util/NameValuePair.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google LLC
+ * Copyright 2013-2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/google/jenkins/plugins/util/NameValuePair.java
+++ b/src/main/java/com/google/jenkins/plugins/util/NameValuePair.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2013 Google Inc. All Rights Reserved.
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/google/jenkins/plugins/util/NotFoundException.java
+++ b/src/main/java/com/google/jenkins/plugins/util/NotFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 Google LLC
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/google/jenkins/plugins/util/NotFoundException.java
+++ b/src/main/java/com/google/jenkins/plugins/util/NotFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google LLC
+ * Copyright 2013-2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/google/jenkins/plugins/util/NotFoundException.java
+++ b/src/main/java/com/google/jenkins/plugins/util/NotFoundException.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2013 Google Inc. All Rights Reserved.
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/google/jenkins/plugins/util/RequestCallable.java
+++ b/src/main/java/com/google/jenkins/plugins/util/RequestCallable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 Google LLC
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/google/jenkins/plugins/util/RequestCallable.java
+++ b/src/main/java/com/google/jenkins/plugins/util/RequestCallable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google LLC
+ * Copyright 2013-2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/google/jenkins/plugins/util/RequestCallable.java
+++ b/src/main/java/com/google/jenkins/plugins/util/RequestCallable.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2013 Google Inc. All Rights Reserved.
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/google/jenkins/plugins/util/Resolve.java
+++ b/src/main/java/com/google/jenkins/plugins/util/Resolve.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 Google LLC
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/google/jenkins/plugins/util/Resolve.java
+++ b/src/main/java/com/google/jenkins/plugins/util/Resolve.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google LLC
+ * Copyright 2013-2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/google/jenkins/plugins/util/Resolve.java
+++ b/src/main/java/com/google/jenkins/plugins/util/Resolve.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2013 Google Inc. All Rights Reserved.
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/resources/com/google/jenkins/plugins/credentials/oauth/GoogleRobotMetadataCredentials/config.jelly
+++ b/src/main/resources/com/google/jenkins/plugins/credentials/oauth/GoogleRobotMetadataCredentials/config.jelly
@@ -1,5 +1,5 @@
 <!--
- Copyright 2013-2019 Google LLC
+ Copyright 2013 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/src/main/resources/com/google/jenkins/plugins/credentials/oauth/GoogleRobotMetadataCredentials/config.jelly
+++ b/src/main/resources/com/google/jenkins/plugins/credentials/oauth/GoogleRobotMetadataCredentials/config.jelly
@@ -1,5 +1,5 @@
 <!--
- Copyright 2019 Google LLC
+ Copyright 2013-2019 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/src/main/resources/com/google/jenkins/plugins/credentials/oauth/GoogleRobotMetadataCredentials/config.jelly
+++ b/src/main/resources/com/google/jenkins/plugins/credentials/oauth/GoogleRobotMetadataCredentials/config.jelly
@@ -1,11 +1,11 @@
 <!--
- Copyright 2013 Google Inc. All Rights Reserved.
+ Copyright 2019 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
  You may obtain a copy of the License at
 
-     http://www.apache.org/licenses/LICENSE-2.0
+     https://www.apache.org/licenses/LICENSE-2.0
 
  Unless required by applicable law or agreed to in writing, software
  distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/resources/com/google/jenkins/plugins/credentials/oauth/GoogleRobotMetadataCredentials/help-projectId.html
+++ b/src/main/resources/com/google/jenkins/plugins/credentials/oauth/GoogleRobotMetadataCredentials/help-projectId.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright 2013-2019 Google LLC
+  Copyright 2013 Google LLC
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/src/main/resources/com/google/jenkins/plugins/credentials/oauth/GoogleRobotMetadataCredentials/help-projectId.html
+++ b/src/main/resources/com/google/jenkins/plugins/credentials/oauth/GoogleRobotMetadataCredentials/help-projectId.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright 2019 Google LLC
+  Copyright 2013-2019 Google LLC
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/src/main/resources/com/google/jenkins/plugins/credentials/oauth/GoogleRobotMetadataCredentials/help-projectId.html
+++ b/src/main/resources/com/google/jenkins/plugins/credentials/oauth/GoogleRobotMetadataCredentials/help-projectId.html
@@ -1,3 +1,18 @@
+<!--
+  Copyright 2019 Google LLC
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
 <div>
  <p>
   This is the <a href="https://cloud.google.com/console">Google Cloud Console</a> project name.

--- a/src/main/resources/com/google/jenkins/plugins/credentials/oauth/GoogleRobotMetadataCredentials/help-projectId.html
+++ b/src/main/resources/com/google/jenkins/plugins/credentials/oauth/GoogleRobotMetadataCredentials/help-projectId.html
@@ -5,7 +5,7 @@
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/resources/com/google/jenkins/plugins/credentials/oauth/GoogleRobotPrivateKeyCredentials/config.jelly
+++ b/src/main/resources/com/google/jenkins/plugins/credentials/oauth/GoogleRobotPrivateKeyCredentials/config.jelly
@@ -1,5 +1,5 @@
 <!--
- Copyright 2013-2019 Google LLC
+ Copyright 2013 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/src/main/resources/com/google/jenkins/plugins/credentials/oauth/GoogleRobotPrivateKeyCredentials/config.jelly
+++ b/src/main/resources/com/google/jenkins/plugins/credentials/oauth/GoogleRobotPrivateKeyCredentials/config.jelly
@@ -1,5 +1,5 @@
 <!--
- Copyright 2019 Google LLC
+ Copyright 2013-2019 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/src/main/resources/com/google/jenkins/plugins/credentials/oauth/GoogleRobotPrivateKeyCredentials/config.jelly
+++ b/src/main/resources/com/google/jenkins/plugins/credentials/oauth/GoogleRobotPrivateKeyCredentials/config.jelly
@@ -1,11 +1,11 @@
 <!--
- Copyright 2013 Google Inc. All Rights Reserved.
+ Copyright 2019 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
  You may obtain a copy of the License at
 
-     http://www.apache.org/licenses/LICENSE-2.0
+     https://www.apache.org/licenses/LICENSE-2.0
 
  Unless required by applicable law or agreed to in writing, software
  distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/resources/com/google/jenkins/plugins/credentials/oauth/GoogleRobotPrivateKeyCredentials/help-credentials.html
+++ b/src/main/resources/com/google/jenkins/plugins/credentials/oauth/GoogleRobotPrivateKeyCredentials/help-credentials.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright 2013-2019 Google LLC
+  Copyright 2013 Google LLC
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/src/main/resources/com/google/jenkins/plugins/credentials/oauth/GoogleRobotPrivateKeyCredentials/help-credentials.html
+++ b/src/main/resources/com/google/jenkins/plugins/credentials/oauth/GoogleRobotPrivateKeyCredentials/help-credentials.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright 2019 Google LLC
+  Copyright 2013-2019 Google LLC
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/src/main/resources/com/google/jenkins/plugins/credentials/oauth/GoogleRobotPrivateKeyCredentials/help-credentials.html
+++ b/src/main/resources/com/google/jenkins/plugins/credentials/oauth/GoogleRobotPrivateKeyCredentials/help-credentials.html
@@ -1,3 +1,18 @@
+<!--
+  Copyright 2019 Google LLC
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
 <div>
   <p>
     The set of Google credentials registered with the Jenkins Credential Manager for authenticating with your project.  This can be configured under "Manage Jenkins" -> "Manage Credentials".<br><br>

--- a/src/main/resources/com/google/jenkins/plugins/credentials/oauth/GoogleRobotPrivateKeyCredentials/help-credentials.html
+++ b/src/main/resources/com/google/jenkins/plugins/credentials/oauth/GoogleRobotPrivateKeyCredentials/help-credentials.html
@@ -5,7 +5,7 @@
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/resources/com/google/jenkins/plugins/credentials/oauth/GoogleRobotPrivateKeyCredentials/help-projectId.html
+++ b/src/main/resources/com/google/jenkins/plugins/credentials/oauth/GoogleRobotPrivateKeyCredentials/help-projectId.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright 2013-2019 Google LLC
+  Copyright 2013 Google LLC
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/src/main/resources/com/google/jenkins/plugins/credentials/oauth/GoogleRobotPrivateKeyCredentials/help-projectId.html
+++ b/src/main/resources/com/google/jenkins/plugins/credentials/oauth/GoogleRobotPrivateKeyCredentials/help-projectId.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright 2019 Google LLC
+  Copyright 2013-2019 Google LLC
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/src/main/resources/com/google/jenkins/plugins/credentials/oauth/GoogleRobotPrivateKeyCredentials/help-projectId.html
+++ b/src/main/resources/com/google/jenkins/plugins/credentials/oauth/GoogleRobotPrivateKeyCredentials/help-projectId.html
@@ -1,3 +1,18 @@
+<!--
+  Copyright 2019 Google LLC
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
 <div>
  <p>
   This is the <a href="https://cloud.google.com/console">Google Cloud Console</a> project name.

--- a/src/main/resources/com/google/jenkins/plugins/credentials/oauth/GoogleRobotPrivateKeyCredentials/help-projectId.html
+++ b/src/main/resources/com/google/jenkins/plugins/credentials/oauth/GoogleRobotPrivateKeyCredentials/help-projectId.html
@@ -5,7 +5,7 @@
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/resources/com/google/jenkins/plugins/credentials/oauth/JsonServiceAccountConfig/config.jelly
+++ b/src/main/resources/com/google/jenkins/plugins/credentials/oauth/JsonServiceAccountConfig/config.jelly
@@ -1,5 +1,5 @@
 <!--
-  Copyright 2014-2019 Google LLC
+  Copyright 2014 Google LLC
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/src/main/resources/com/google/jenkins/plugins/credentials/oauth/JsonServiceAccountConfig/config.jelly
+++ b/src/main/resources/com/google/jenkins/plugins/credentials/oauth/JsonServiceAccountConfig/config.jelly
@@ -1,5 +1,5 @@
 <!--
-  Copyright 2019 Google LLC
+  Copyright 2014-2019 Google LLC
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/src/main/resources/com/google/jenkins/plugins/credentials/oauth/JsonServiceAccountConfig/config.jelly
+++ b/src/main/resources/com/google/jenkins/plugins/credentials/oauth/JsonServiceAccountConfig/config.jelly
@@ -1,3 +1,18 @@
+<!--
+  Copyright 2019 Google LLC
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core"
          xmlns:f="/lib/form">

--- a/src/main/resources/com/google/jenkins/plugins/credentials/oauth/JsonServiceAccountConfig/config.jelly
+++ b/src/main/resources/com/google/jenkins/plugins/credentials/oauth/JsonServiceAccountConfig/config.jelly
@@ -5,7 +5,7 @@
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/resources/com/google/jenkins/plugins/credentials/oauth/JsonServiceAccountConfig/help-jsonKeyFile.html
+++ b/src/main/resources/com/google/jenkins/plugins/credentials/oauth/JsonServiceAccountConfig/help-jsonKeyFile.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright 2014-2019 Google LLC
+  Copyright 2014 Google LLC
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/src/main/resources/com/google/jenkins/plugins/credentials/oauth/JsonServiceAccountConfig/help-jsonKeyFile.html
+++ b/src/main/resources/com/google/jenkins/plugins/credentials/oauth/JsonServiceAccountConfig/help-jsonKeyFile.html
@@ -1,3 +1,18 @@
+<!--
+  Copyright 2019 Google LLC
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
 <div>
   <p>
     This is the "{project name}-xxxxxxxxxxxx.json" file associated with the service account credential in

--- a/src/main/resources/com/google/jenkins/plugins/credentials/oauth/JsonServiceAccountConfig/help-jsonKeyFile.html
+++ b/src/main/resources/com/google/jenkins/plugins/credentials/oauth/JsonServiceAccountConfig/help-jsonKeyFile.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright 2019 Google LLC
+  Copyright 2014-2019 Google LLC
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/src/main/resources/com/google/jenkins/plugins/credentials/oauth/JsonServiceAccountConfig/help-jsonKeyFile.html
+++ b/src/main/resources/com/google/jenkins/plugins/credentials/oauth/JsonServiceAccountConfig/help-jsonKeyFile.html
@@ -5,7 +5,7 @@
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/resources/com/google/jenkins/plugins/credentials/oauth/Messages.properties
+++ b/src/main/resources/com/google/jenkins/plugins/credentials/oauth/Messages.properties
@@ -1,4 +1,4 @@
-# Copyright 2013-2019 Google LLC
+# Copyright 2013 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/resources/com/google/jenkins/plugins/credentials/oauth/Messages.properties
+++ b/src/main/resources/com/google/jenkins/plugins/credentials/oauth/Messages.properties
@@ -1,10 +1,10 @@
-# Copyright 2013 Google Inc. All Rights Reserved.
+# Copyright 2019 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/resources/com/google/jenkins/plugins/credentials/oauth/Messages.properties
+++ b/src/main/resources/com/google/jenkins/plugins/credentials/oauth/Messages.properties
@@ -1,4 +1,4 @@
-# Copyright 2019 Google LLC
+# Copyright 2013-2019 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/resources/com/google/jenkins/plugins/credentials/oauth/P12ServiceAccountConfig/config.jelly
+++ b/src/main/resources/com/google/jenkins/plugins/credentials/oauth/P12ServiceAccountConfig/config.jelly
@@ -1,5 +1,5 @@
 <!--
-  Copyright 2014-2019 Google LLC
+  Copyright 2014 Google LLC
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/src/main/resources/com/google/jenkins/plugins/credentials/oauth/P12ServiceAccountConfig/config.jelly
+++ b/src/main/resources/com/google/jenkins/plugins/credentials/oauth/P12ServiceAccountConfig/config.jelly
@@ -1,3 +1,18 @@
+<!--
+  Copyright 2014-2019 Google LLC
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core"
          xmlns:f="/lib/form">

--- a/src/main/resources/com/google/jenkins/plugins/credentials/oauth/P12ServiceAccountConfig/help-emailAddress.html
+++ b/src/main/resources/com/google/jenkins/plugins/credentials/oauth/P12ServiceAccountConfig/help-emailAddress.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright 2014-2019 Google LLC
+  Copyright 2014 Google LLC
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/src/main/resources/com/google/jenkins/plugins/credentials/oauth/P12ServiceAccountConfig/help-emailAddress.html
+++ b/src/main/resources/com/google/jenkins/plugins/credentials/oauth/P12ServiceAccountConfig/help-emailAddress.html
@@ -1,3 +1,18 @@
+<!--
+  Copyright 2014-2019 Google LLC
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
 <div>
   <p>
     This is the E-Mail address associated with the service account credential in the

--- a/src/main/resources/com/google/jenkins/plugins/credentials/oauth/P12ServiceAccountConfig/help-p12KeyFile.html
+++ b/src/main/resources/com/google/jenkins/plugins/credentials/oauth/P12ServiceAccountConfig/help-p12KeyFile.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright 2014-2019 Google LLC
+  Copyright 2014 Google LLC
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/src/main/resources/com/google/jenkins/plugins/credentials/oauth/P12ServiceAccountConfig/help-p12KeyFile.html
+++ b/src/main/resources/com/google/jenkins/plugins/credentials/oauth/P12ServiceAccountConfig/help-p12KeyFile.html
@@ -1,3 +1,18 @@
+<!--
+  Copyright 2014-2019 Google LLC
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
 <div>
   <p>
     This is the "{project name}-xxxxxxxxxxxx.p12" file associated with the service account credential in

--- a/src/main/resources/com/google/jenkins/plugins/util/Messages.properties
+++ b/src/main/resources/com/google/jenkins/plugins/util/Messages.properties
@@ -1,4 +1,4 @@
-# Copyright 2013-2019 Google LLC
+# Copyright 2013 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/resources/com/google/jenkins/plugins/util/Messages.properties
+++ b/src/main/resources/com/google/jenkins/plugins/util/Messages.properties
@@ -1,10 +1,10 @@
-# Copyright 2013 Google Inc. All Rights Reserved.
+# Copyright 2019 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/resources/com/google/jenkins/plugins/util/Messages.properties
+++ b/src/main/resources/com/google/jenkins/plugins/util/Messages.properties
@@ -1,4 +1,4 @@
-# Copyright 2019 Google LLC
+# Copyright 2013-2019 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/resources/lib/auth/credentials.jelly
+++ b/src/main/resources/lib/auth/credentials.jelly
@@ -1,5 +1,5 @@
 <!--
- Copyright 2013-2019 Google LLC
+ Copyright 2013 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/src/main/resources/lib/auth/credentials.jelly
+++ b/src/main/resources/lib/auth/credentials.jelly
@@ -1,5 +1,5 @@
 <!--
- Copyright 2019 Google LLC
+ Copyright 2013-2019 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/src/main/resources/lib/auth/credentials.jelly
+++ b/src/main/resources/lib/auth/credentials.jelly
@@ -1,11 +1,11 @@
 <!--
- Copyright 2013 Google Inc. All Rights Reserved.
+ Copyright 2019 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
  You may obtain a copy of the License at
 
-     http://www.apache.org/licenses/LICENSE-2.0
+     https://www.apache.org/licenses/LICENSE-2.0
 
  Unless required by applicable law or agreed to in writing, software
  distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/com/google/jenkins/plugins/credentials/oauth/GoogleOAuth2ScopeSpecificationTest.java
+++ b/src/test/java/com/google/jenkins/plugins/credentials/oauth/GoogleOAuth2ScopeSpecificationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 Google LLC
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/google/jenkins/plugins/credentials/oauth/GoogleOAuth2ScopeSpecificationTest.java
+++ b/src/test/java/com/google/jenkins/plugins/credentials/oauth/GoogleOAuth2ScopeSpecificationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google LLC
+ * Copyright 2013-2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/google/jenkins/plugins/credentials/oauth/GoogleOAuth2ScopeSpecificationTest.java
+++ b/src/test/java/com/google/jenkins/plugins/credentials/oauth/GoogleOAuth2ScopeSpecificationTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2013 Google Inc. All Rights Reserved.
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotCredentialsTest.java
+++ b/src/test/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotCredentialsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 Google LLC
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotCredentialsTest.java
+++ b/src/test/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotCredentialsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google LLC
+ * Copyright 2013-2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotCredentialsTest.java
+++ b/src/test/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotCredentialsTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2013 Google Inc. All Rights Reserved.
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotMetadataCredentialsTest.java
+++ b/src/test/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotMetadataCredentialsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 Google LLC
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotMetadataCredentialsTest.java
+++ b/src/test/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotMetadataCredentialsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google LLC
+ * Copyright 2013-2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotMetadataCredentialsTest.java
+++ b/src/test/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotMetadataCredentialsTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2013 Google Inc. All Rights Reserved.
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotPrivateKeyCredentialsTest.java
+++ b/src/test/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotPrivateKeyCredentialsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 Google LLC
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotPrivateKeyCredentialsTest.java
+++ b/src/test/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotPrivateKeyCredentialsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google LLC
+ * Copyright 2013-2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotPrivateKeyCredentialsTest.java
+++ b/src/test/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotPrivateKeyCredentialsTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2013 Google Inc. All Rights Reserved.
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/com/google/jenkins/plugins/credentials/oauth/JsonServiceAccountConfigTest.java
+++ b/src/test/java/com/google/jenkins/plugins/credentials/oauth/JsonServiceAccountConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google LLC
+ * Copyright 2014-2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/google/jenkins/plugins/credentials/oauth/JsonServiceAccountConfigTest.java
+++ b/src/test/java/com/google/jenkins/plugins/credentials/oauth/JsonServiceAccountConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 Google LLC
+ * Copyright 2014 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/google/jenkins/plugins/credentials/oauth/JsonServiceAccountConfigTest.java
+++ b/src/test/java/com/google/jenkins/plugins/credentials/oauth/JsonServiceAccountConfigTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2013 Google Inc. All Rights Reserved.
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/com/google/jenkins/plugins/credentials/oauth/JsonServiceAccountConfigTestUtil.java
+++ b/src/test/java/com/google/jenkins/plugins/credentials/oauth/JsonServiceAccountConfigTestUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google LLC
+ * Copyright 2014-2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/google/jenkins/plugins/credentials/oauth/JsonServiceAccountConfigTestUtil.java
+++ b/src/test/java/com/google/jenkins/plugins/credentials/oauth/JsonServiceAccountConfigTestUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 Google LLC
+ * Copyright 2014 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/google/jenkins/plugins/credentials/oauth/JsonServiceAccountConfigTestUtil.java
+++ b/src/test/java/com/google/jenkins/plugins/credentials/oauth/JsonServiceAccountConfigTestUtil.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2013 Google Inc. All Rights Reserved.
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/com/google/jenkins/plugins/credentials/oauth/LegacyJsonServiceAccountConfigUtil.java
+++ b/src/test/java/com/google/jenkins/plugins/credentials/oauth/LegacyJsonServiceAccountConfigUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google LLC
+ * Copyright 2014-2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/google/jenkins/plugins/credentials/oauth/LegacyJsonServiceAccountConfigUtil.java
+++ b/src/test/java/com/google/jenkins/plugins/credentials/oauth/LegacyJsonServiceAccountConfigUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 Google LLC
+ * Copyright 2014 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/google/jenkins/plugins/credentials/oauth/LegacyJsonServiceAccountConfigUtil.java
+++ b/src/test/java/com/google/jenkins/plugins/credentials/oauth/LegacyJsonServiceAccountConfigUtil.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2013 Google Inc. All Rights Reserved.
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/com/google/jenkins/plugins/credentials/oauth/P12ServiceAccountConfigTest.java
+++ b/src/test/java/com/google/jenkins/plugins/credentials/oauth/P12ServiceAccountConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google LLC
+ * Copyright 2014-2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/google/jenkins/plugins/credentials/oauth/P12ServiceAccountConfigTest.java
+++ b/src/test/java/com/google/jenkins/plugins/credentials/oauth/P12ServiceAccountConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 Google LLC
+ * Copyright 2014 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/google/jenkins/plugins/credentials/oauth/P12ServiceAccountConfigTest.java
+++ b/src/test/java/com/google/jenkins/plugins/credentials/oauth/P12ServiceAccountConfigTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2013 Google Inc. All Rights Reserved.
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/com/google/jenkins/plugins/credentials/oauth/P12ServiceAccountConfigTestUtil.java
+++ b/src/test/java/com/google/jenkins/plugins/credentials/oauth/P12ServiceAccountConfigTestUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google LLC
+ * Copyright 2014-2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/google/jenkins/plugins/credentials/oauth/P12ServiceAccountConfigTestUtil.java
+++ b/src/test/java/com/google/jenkins/plugins/credentials/oauth/P12ServiceAccountConfigTestUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 Google LLC
+ * Copyright 2014 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/google/jenkins/plugins/credentials/oauth/P12ServiceAccountConfigTestUtil.java
+++ b/src/test/java/com/google/jenkins/plugins/credentials/oauth/P12ServiceAccountConfigTestUtil.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2013 Google Inc. All Rights Reserved.
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/com/google/jenkins/plugins/credentials/oauth/RemotableGoogleCredentialsTest.java
+++ b/src/test/java/com/google/jenkins/plugins/credentials/oauth/RemotableGoogleCredentialsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 Google LLC
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/google/jenkins/plugins/credentials/oauth/RemotableGoogleCredentialsTest.java
+++ b/src/test/java/com/google/jenkins/plugins/credentials/oauth/RemotableGoogleCredentialsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google LLC
+ * Copyright 2013-2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/google/jenkins/plugins/credentials/oauth/RemotableGoogleCredentialsTest.java
+++ b/src/test/java/com/google/jenkins/plugins/credentials/oauth/RemotableGoogleCredentialsTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2013 Google Inc. All Rights Reserved.
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/com/google/jenkins/plugins/credentials/oauth/SerializationUtil.java
+++ b/src/test/java/com/google/jenkins/plugins/credentials/oauth/SerializationUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google LLC
+ * Copyright 2014-2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/google/jenkins/plugins/credentials/oauth/SerializationUtil.java
+++ b/src/test/java/com/google/jenkins/plugins/credentials/oauth/SerializationUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 Google LLC
+ * Copyright 2014 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/google/jenkins/plugins/credentials/oauth/SerializationUtil.java
+++ b/src/test/java/com/google/jenkins/plugins/credentials/oauth/SerializationUtil.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2013 Google Inc. All Rights Reserved.
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/com/google/jenkins/plugins/credentials/oauth/TestGoogleOAuth2DomainRequirement.java
+++ b/src/test/java/com/google/jenkins/plugins/credentials/oauth/TestGoogleOAuth2DomainRequirement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 Google LLC
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/google/jenkins/plugins/credentials/oauth/TestGoogleOAuth2DomainRequirement.java
+++ b/src/test/java/com/google/jenkins/plugins/credentials/oauth/TestGoogleOAuth2DomainRequirement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google LLC
+ * Copyright 2013-2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/google/jenkins/plugins/credentials/oauth/TestGoogleOAuth2DomainRequirement.java
+++ b/src/test/java/com/google/jenkins/plugins/credentials/oauth/TestGoogleOAuth2DomainRequirement.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2013 Google Inc. All Rights Reserved.
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/com/google/jenkins/plugins/credentials/oauth/TestRobotBuilder.java
+++ b/src/test/java/com/google/jenkins/plugins/credentials/oauth/TestRobotBuilder.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2013 Google Inc. All Rights Reserved.
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/com/google/jenkins/plugins/credentials/oauth/TestRobotBuilder.java
+++ b/src/test/java/com/google/jenkins/plugins/credentials/oauth/TestRobotBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 Google LLC
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/google/jenkins/plugins/credentials/oauth/TestRobotBuilder.java
+++ b/src/test/java/com/google/jenkins/plugins/credentials/oauth/TestRobotBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 Google LLC
+ * Copyright 2013-2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/google/jenkins/plugins/util/ExecutorTest.java
+++ b/src/test/java/com/google/jenkins/plugins/util/ExecutorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 Google LLC
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/google/jenkins/plugins/util/ExecutorTest.java
+++ b/src/test/java/com/google/jenkins/plugins/util/ExecutorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google LLC
+ * Copyright 2013-2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/google/jenkins/plugins/util/ExecutorTest.java
+++ b/src/test/java/com/google/jenkins/plugins/util/ExecutorTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2013 Google Inc. All Rights Reserved.
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/com/google/jenkins/plugins/util/MetadataReaderTest.java
+++ b/src/test/java/com/google/jenkins/plugins/util/MetadataReaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 Google LLC
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/google/jenkins/plugins/util/MetadataReaderTest.java
+++ b/src/test/java/com/google/jenkins/plugins/util/MetadataReaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google LLC
+ * Copyright 2013-2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/google/jenkins/plugins/util/MetadataReaderTest.java
+++ b/src/test/java/com/google/jenkins/plugins/util/MetadataReaderTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2013 Google Inc. All Rights Reserved.
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/com/google/jenkins/plugins/util/MockExecutorTest.java
+++ b/src/test/java/com/google/jenkins/plugins/util/MockExecutorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 Google LLC
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/google/jenkins/plugins/util/MockExecutorTest.java
+++ b/src/test/java/com/google/jenkins/plugins/util/MockExecutorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google LLC
+ * Copyright 2013-2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/google/jenkins/plugins/util/MockExecutorTest.java
+++ b/src/test/java/com/google/jenkins/plugins/util/MockExecutorTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2013 Google Inc. All Rights Reserved.
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/com/google/jenkins/plugins/util/NameValuePairTest.java
+++ b/src/test/java/com/google/jenkins/plugins/util/NameValuePairTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 Google LLC
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/google/jenkins/plugins/util/NameValuePairTest.java
+++ b/src/test/java/com/google/jenkins/plugins/util/NameValuePairTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google LLC
+ * Copyright 2013-2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/google/jenkins/plugins/util/NameValuePairTest.java
+++ b/src/test/java/com/google/jenkins/plugins/util/NameValuePairTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2013 Google Inc. All Rights Reserved.
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/com/google/jenkins/plugins/util/ResolveTest.java
+++ b/src/test/java/com/google/jenkins/plugins/util/ResolveTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 Google LLC
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/google/jenkins/plugins/util/ResolveTest.java
+++ b/src/test/java/com/google/jenkins/plugins/util/ResolveTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google LLC
+ * Copyright 2013-2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/google/jenkins/plugins/util/ResolveTest.java
+++ b/src/test/java/com/google/jenkins/plugins/util/ResolveTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2013 Google Inc. All Rights Reserved.
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
Apart from adding the header to the files that were missing it, I'm changing the existing headers to match the apache header listed in the open source releasing guide, available externally [here](https://opensource.google.com/docs/releasing/preparing/#Apache-header)


