### PR TITLE
Make sure that a newly submitted file is submitted last

### DIFF
--- a/src/main/resources/com/google/jenkins/plugins/credentials/oauth/JsonServiceAccountConfig/config.jelly
+++ b/src/main/resources/com/google/jenkins/plugins/credentials/oauth/JsonServiceAccountConfig/config.jelly
@@ -16,6 +16,12 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core"
          xmlns:f="/lib/form">
+  <f:invisibleEntry>
+    <f:textbox field="filename"/>
+  </f:invisibleEntry>
+  <f:invisibleEntry>
+    <f:textbox field="secretJsonKey"/>
+  </f:invisibleEntry>
   <f:entry field="jsonKeyFileUpload"
            title="${%JSON key File}">
     <input jsonAware="yes"
@@ -28,10 +34,4 @@
       </label>
     </j:if>
   </f:entry>
-  <f:invisibleEntry>
-    <f:textbox field="filename"/>
-  </f:invisibleEntry>
-  <f:invisibleEntry>
-    <f:textbox field="secretJsonKey"/>
-  </f:invisibleEntry>
 </j:jelly>

--- a/src/main/resources/com/google/jenkins/plugins/credentials/oauth/P12ServiceAccountConfig/config.jelly
+++ b/src/main/resources/com/google/jenkins/plugins/credentials/oauth/P12ServiceAccountConfig/config.jelly
@@ -20,6 +20,12 @@
            title="${%E-Mail Address}">
     <f:textbox />
   </f:entry>
+  <f:invisibleEntry>
+    <f:textbox field="filename"/>
+  </f:invisibleEntry>
+  <f:invisibleEntry>
+    <f:textbox field="secretP12Key"/>
+  </f:invisibleEntry>
   <f:entry field="p12KeyFileUpload"
            title="${%P12 key File}">
     <input jsonAware="yes"
@@ -32,10 +38,4 @@
       </label>
     </j:if>
   </f:entry>
-  <f:invisibleEntry>
-    <f:textbox field="filename"/>
-  </f:invisibleEntry>
-  <f:invisibleEntry>
-    <f:textbox field="secretP12Key"/>
-  </f:invisibleEntry>
 </j:jelly>


### PR DESCRIPTION
While testing this in the UI I discovered that the ordering of the elements matters here, particularly when updating an existing credential. Right now, a newly uploaded file is just overwritten again by the existing filename and secret. By putting the file item last it won't be overwritten. This is not a concern for the reverse case where we submit without uploading a new file, because the file item will be null and the existing filename and secret will be set properly.