### PR TITLE
Clean CasC deps

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.36</version>
+    <version>3.43</version>
   </parent>
 
   <!--

--- a/pom.xml
+++ b/pom.xml
@@ -72,10 +72,10 @@
 
   <!-- Bring some sanity to version numbering... -->
   <properties>
-    <jenkins.version>2.60.3</jenkins.version>
+    <jenkins.version>2.138.4</jenkins.version>
     <google.api.version>1.24.1</google.api.version>
-    <configuration-as-code.version>1.9</configuration-as-code.version>
-    <credentials.version>2.1.16</credentials.version>
+    <configuration-as-code.version>1.19</configuration-as-code.version>
+    <credentials.version>2.2.0</credentials.version>
     <java.level>8</java.level>
     <findbugs.excludeFilterFile>findbugs-exclude.xml</findbugs.excludeFilterFile>
     <findbugs.effort>Max</findbugs.effort>
@@ -130,27 +130,6 @@
       <artifactId>configuration-as-code</artifactId>
       <version>${configuration-as-code.version}</version>
       <classifier>tests</classifier>
-      <scope>test</scope>
-      <optional>true</optional>
-    </dependency>
-    <dependency>
-      <groupId>io.jenkins.configuration-as-code</groupId>
-      <artifactId>configuration-as-code-support</artifactId>
-      <version>${configuration-as-code.version}</version>
-      <scope>test</scope>
-      <optional>true</optional>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>plain-credentials</artifactId>
-      <version>1.5</version>
-      <scope>test</scope>
-      <optional>true</optional>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>ssh-credentials</artifactId>
-      <version>1.13</version>
       <scope>test</scope>
       <optional>true</optional>
     </dependency>

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotCredentials.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotCredentials.java
@@ -76,7 +76,7 @@ public abstract class GoogleRobotCredentials implements GoogleOAuth2Credentials 
   @Override
   public AbstractGoogleRobotCredentialsDescriptor getDescriptor() {
     return (AbstractGoogleRobotCredentialsDescriptor)
-        Jenkins.getInstance().getDescriptorOrDie(getClass());
+        Jenkins.get().getDescriptorOrDie(getClass());
   }
 
   /** {@inheritDoc} */
@@ -94,9 +94,7 @@ public abstract class GoogleRobotCredentials implements GoogleOAuth2Credentials 
       }
 
       return Secret.fromString(credential.getAccessToken());
-    } catch (IOException e) {
-      return null;
-    } catch (GeneralSecurityException e) {
+    } catch (IOException | GeneralSecurityException e) {
       return null;
     }
   }
@@ -145,9 +143,9 @@ public abstract class GoogleRobotCredentials implements GoogleOAuth2Credentials 
     Iterable<GoogleRobotCredentials> allGoogleCredentials =
         CredentialsProvider.lookupCredentials(
             GoogleRobotCredentials.class,
-            Jenkins.getInstance(),
+            Jenkins.get(),
             ACL.SYSTEM,
-            ImmutableList.<DomainRequirement>of(requirement));
+            ImmutableList.of(requirement));
 
     for (GoogleRobotCredentials credentials : allGoogleCredentials) {
       String name = CredentialsNameProvider.name(credentials);
@@ -161,7 +159,7 @@ public abstract class GoogleRobotCredentials implements GoogleOAuth2Credentials 
     Iterable<GoogleRobotCredentials> allGoogleCredentials =
         CredentialsProvider.lookupCredentials(
             GoogleRobotCredentials.class,
-            Jenkins.getInstance(),
+            Jenkins.get(),
             ACL.SYSTEM,
             Collections.emptyList());
 

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotMetadataCredentials.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotMetadataCredentials.java
@@ -74,7 +74,7 @@ public final class GoogleRobotMetadataCredentials extends GoogleRobotCredentials
           new Domain(
               "metadata",
               "",
-              ImmutableList.<DomainSpecification>of(
+              ImmutableList.of(
                   new GoogleOAuth2ScopeSpecification(getDescriptor().defaultScopes())));
     }
     return metadataScopes.test(requirements);
@@ -87,10 +87,7 @@ public final class GoogleRobotMetadataCredentials extends GoogleRobotCredentials
   public String getUsername() {
     try {
       return getModule().getMetadataReader().readMetadata(IDENTITY_PATH);
-    } catch (ExecutorException e) {
-      throw new IllegalStateException(
-          Messages.GoogleRobotMetadataCredentials_DefaultIdentityError(), e);
-    } catch (IOException e) {
+    } catch (ExecutorException | IOException e) {
       throw new IllegalStateException(
           Messages.GoogleRobotMetadataCredentials_DefaultIdentityError(), e);
     }
@@ -180,9 +177,7 @@ public final class GoogleRobotMetadataCredentials extends GoogleRobotCredentials
     public String defaultProject() {
       try {
         return getModule().getMetadataReader().readMetadata(PROJECT_ID_PATH);
-      } catch (ExecutorException e) {
-        return null;
-      } catch (IOException e) {
+      } catch (ExecutorException | IOException e) {
         return null;
       }
     }
@@ -198,9 +193,7 @@ public final class GoogleRobotMetadataCredentials extends GoogleRobotCredentials
         String scopes = getModule().getMetadataReader().readMetadata(SCOPES_PATH);
 
         return Lists.newArrayList(Splitter.on('\n').trimResults().omitEmptyStrings().split(scopes));
-      } catch (ExecutorException e) {
-        return ImmutableList.of();
-      } catch (IOException e) {
+      } catch (ExecutorException | IOException e) {
         return ImmutableList.of();
       }
     }

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotPrivateKeyCredentials.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotPrivateKeyCredentials.java
@@ -139,7 +139,7 @@ public final class GoogleRobotPrivateKeyCredentials extends GoogleRobotCredentia
    * @return list of possible {@link ServiceAccountConfig}s
    */
   public static List<ServiceAccountConfig.Descriptor> getServiceAccountConfigDescriptors() {
-    Jenkins instance = Jenkins.getInstance();
+    Jenkins instance = Jenkins.get();
     return ImmutableList.of(
         (ServiceAccountConfig.Descriptor)
             instance.getDescriptorOrDie(JsonServiceAccountConfig.class),
@@ -165,7 +165,7 @@ public final class GoogleRobotPrivateKeyCredentials extends GoogleRobotCredentia
    * details see {@code /lib/auth/credentials.jelly}.
    */
   public static String getHelpFile() {
-    return Jenkins.getInstance()
+    return Jenkins.get()
         .getDescriptorOrDie(GoogleRobotPrivateKeyCredentials.class)
         .getHelpFile("credentials");
   }

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/JsonServiceAccountConfig.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/JsonServiceAccountConfig.java
@@ -161,7 +161,7 @@ public class JsonServiceAccountConfig extends ServiceAccountConfig {
   @Override
   public DescriptorImpl getDescriptor() {
     return (DescriptorImpl)
-        Jenkins.getInstance().getDescriptorOrDie(JsonServiceAccountConfig.class);
+        Jenkins.get().getDescriptorOrDie(JsonServiceAccountConfig.class);
   }
 
   /**

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/P12ServiceAccountConfig.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/P12ServiceAccountConfig.java
@@ -155,7 +155,7 @@ public class P12ServiceAccountConfig extends ServiceAccountConfig {
 
   @Override
   public DescriptorImpl getDescriptor() {
-    return (DescriptorImpl) Jenkins.getInstance().getDescriptorOrDie(P12ServiceAccountConfig.class);
+    return (DescriptorImpl) Jenkins.get().getDescriptorOrDie(P12ServiceAccountConfig.class);
   }
 
   public String getEmailAddress() {

--- a/src/main/java/com/google/jenkins/plugins/util/MetadataReader.java
+++ b/src/main/java/com/google/jenkins/plugins/util/MetadataReader.java
@@ -90,16 +90,11 @@ public interface MetadataReader {
         }
       }
 
-      InputStreamReader inChars = null;
-      try {
-        inChars = new InputStreamReader(checkNotNull(response.getContent()), Charsets.UTF_8);
+      try (InputStreamReader inChars = new InputStreamReader(checkNotNull(response.getContent()),
+          Charsets.UTF_8)) {
         StringWriter output = new StringWriter();
         copy(inChars, output);
         return output.toString();
-      } finally {
-        if (inChars != null) {
-          inChars.close();
-        }
       }
     }
 
@@ -109,9 +104,7 @@ public interface MetadataReader {
       try {
         readMetadata("");
         return true;
-      } catch (IOException e) {
-        return false;
-      } catch (ExecutorException e) {
+      } catch (IOException | ExecutorException e) {
         return false;
       }
     }

--- a/src/main/java/com/google/jenkins/plugins/util/MockExecutor.java
+++ b/src/main/java/com/google/jenkins/plugins/util/MockExecutor.java
@@ -35,10 +35,10 @@ import java.util.LinkedList;
  */
 public class MockExecutor extends Executor {
   public MockExecutor() {
-    requestTypes = new LinkedList<Class<?>>();
-    responses = new LinkedList<Object>();
-    exceptions = new LinkedList<Exception>();
-    predicates = new LinkedList<Predicate<?>>();
+    requestTypes = new LinkedList<>();
+    responses = new LinkedList<>();
+    exceptions = new LinkedList<>();
+    predicates = new LinkedList<>();
     sawUnexpected = false;
   }
 
@@ -115,7 +115,7 @@ public class MockExecutor extends Executor {
    */
   public <T, C extends AbstractGoogleJsonClientRequest<T>> void when(
       Class<C> requestType, T response) {
-    when(requestType, response, Predicates.<C>alwaysTrue());
+    when(requestType, response, Predicates.alwaysTrue());
   }
 
   /**
@@ -133,7 +133,7 @@ public class MockExecutor extends Executor {
    */
   public <T, C extends AbstractGoogleJsonClientRequest<T>> void throwWhen(
       Class<C> requestType, IOException exception) {
-    throwWhen(requestType, exception, Predicates.<C>alwaysTrue());
+    throwWhen(requestType, exception, Predicates.alwaysTrue());
   }
 
   /**
@@ -151,7 +151,7 @@ public class MockExecutor extends Executor {
    */
   public <T, C extends AbstractGoogleJsonClientRequest<T>> void throwWhen(
       Class<C> requestType, ExecutorException exception) {
-    throwWhen(requestType, exception, Predicates.<C>alwaysTrue());
+    throwWhen(requestType, exception, Predicates.alwaysTrue());
   }
 
   /**
@@ -184,7 +184,7 @@ public class MockExecutor extends Executor {
    * getJsonContent()} cast to the expected response type.
    */
   public <T, C extends AbstractGoogleJsonClientRequest<T>> void passThruWhen(Class<C> requestType) {
-    passThruWhen(requestType, Predicates.<C>alwaysTrue());
+    passThruWhen(requestType, Predicates.alwaysTrue());
   }
 
   /** Did we see all of the expected requests? */

--- a/src/main/java/com/google/jenkins/plugins/util/Resolve.java
+++ b/src/main/java/com/google/jenkins/plugins/util/Resolve.java
@@ -37,7 +37,7 @@ public final class Resolve {
    * @return the string with substitutions made for built-in variables.
    */
   public static String resolveBuiltin(String input) {
-    return resolveBuiltinWithCustom(checkNotNull(input), Collections.<String, String>emptyMap());
+    return resolveBuiltinWithCustom(checkNotNull(input), Collections.emptyMap());
   }
 
   /**
@@ -54,7 +54,7 @@ public final class Resolve {
     checkNotNull(customEnvironment);
 
     // Combine customEnvironment and sampleEnvironment into a new map.
-    Map<String, String> combinedEnvironment = new HashMap<String, String>();
+    Map<String, String> combinedEnvironment = new HashMap<>();
     combinedEnvironment.putAll(defaultValues);
     combinedEnvironment.putAll(customEnvironment); // allow overriding defaults
 
@@ -76,7 +76,7 @@ public final class Resolve {
     return Util.replaceMacro(input, customEnvironment);
   }
 
-  private static Map<String, String> defaultValues = new HashMap<String, String>();
+  private static Map<String, String> defaultValues = new HashMap<>();
 
   // See: http://wiki.jenkins-ci.org/display/JENKINS/Building+a+software+project
   static {


### PR DESCRIPTION
credentials version 2.2.0 updated their Jenkins core to 2.138.4.

Looking at the stats: http://stats.jenkins.io/pluginversions/google-oauth-plugin.html that would mean 73% are already on that version or newer.

Though their numbers are 69%: http://stats.jenkins.io/pluginversions/credentials.html

(hint: You hover over `SUM` to see the percentage)

I think I can do another pull request if the Jenkins core bump is bothering you.
Where we would still depend on JCasC support but I should be able to remove ssh credentials and plain credentials. Since we solved some of the dependency issue we had in the support plugin.