### PR TITLE
Fix dependency conflicts with api client and guava.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,8 @@
   <!-- Bring some sanity to version numbering... -->
   <properties>
     <jenkins.version>2.138.4</jenkins.version>
-    <google.api.version>1.29.2</google.api.version>
+    <!-- TODO: Update this version when Jenkins core does not bundle guava 11. -->
+    <google.api.version>1.24.1</google.api.version>
     <configuration-as-code.version>1.19</configuration-as-code.version>
     <credentials.version>2.2.0</credentials.version>
     <java.level>8</java.level>
@@ -142,7 +143,7 @@
     </dependency>
     <dependency>
       <groupId>com.google.http-client</groupId>
-      <artifactId>google-http-client-jackson</artifactId>
+      <artifactId>google-http-client-jackson2</artifactId>
       <version>${google.api.version}</version>
     </dependency>
     <!-- com.google.api-client -->
@@ -156,7 +157,7 @@
     <dependency>
       <groupId>com.google.apis</groupId>
       <artifactId>google-api-services-oauth2</artifactId>
-      <version>v2-rev20190313-${google.api.version}</version>
+      <version>v2-rev140-${google.api.version}</version>
     </dependency>
     <!-- plugin dependencies -->
     <dependency>

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotCredentialsModule.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotCredentialsModule.java
@@ -18,7 +18,7 @@ package com.google.jenkins.plugins.credentials.oauth;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.http.javanet.NetHttpTransport;
 import com.google.api.client.json.JsonFactory;
-import com.google.api.client.json.jackson.JacksonFactory;
+import com.google.api.client.json.jackson2.JacksonFactory;
 import java.io.Serializable;
 
 /**

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotPrivateKeyCredentials.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotPrivateKeyCredentials.java
@@ -17,6 +17,7 @@ package com.google.jenkins.plugins.credentials.oauth;
 
 import com.cloudbees.plugins.credentials.CredentialsScope;
 import com.cloudbees.plugins.credentials.NameWith;
+import com.fasterxml.jackson.core.JsonParseException;
 import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
@@ -29,7 +30,6 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nullable;
 import jenkins.model.Jenkins;
-import org.codehaus.jackson.JsonParseException;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 /**

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/JsonServiceAccountConfig.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/JsonServiceAccountConfig.java
@@ -16,7 +16,7 @@
 package com.google.jenkins.plugins.credentials.oauth;
 
 import com.cloudbees.plugins.credentials.SecretBytes;
-import com.google.api.client.json.jackson.JacksonFactory;
+import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.client.util.PemReader;
 import com.google.api.client.util.Strings;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;

--- a/src/test/java/com/google/jenkins/GoogleOAuthPluginTestSuite.java
+++ b/src/test/java/com/google/jenkins/GoogleOAuthPluginTestSuite.java
@@ -20,9 +20,7 @@ import com.google.jenkins.plugins.UtilTestSuite;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 
-/**
- * Defines the full test suite for the Google Oauth Plugin.
- */
+/** Defines the full test suite for the Google Oauth Plugin. */
 @RunWith(Suite.class)
 @Suite.SuiteClasses(value = {CredentialsOAuthTestSuite.class, UtilTestSuite.class})
 public class GoogleOAuthPluginTestSuite {}

--- a/src/test/java/com/google/jenkins/plugins/CredentialsOAuthTestSuite.java
+++ b/src/test/java/com/google/jenkins/plugins/CredentialsOAuthTestSuite.java
@@ -26,9 +26,7 @@ import com.google.jenkins.plugins.credentials.oauth.RemotableGoogleCredentialsTe
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 
-/**
- * Defines the full test suite involving OAuth credentials.
- */
+/** Defines the full test suite involving OAuth credentials. */
 @RunWith(Suite.class)
 @Suite.SuiteClasses(
     value = {

--- a/src/test/java/com/google/jenkins/plugins/UtilTestSuite.java
+++ b/src/test/java/com/google/jenkins/plugins/UtilTestSuite.java
@@ -23,9 +23,7 @@ import com.google.jenkins.plugins.util.ResolveTest;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 
-/**
- * Defines the full test suite for utility classes.
- */
+/** Defines the full test suite for utility classes. */
 @RunWith(Suite.class)
 @Suite.SuiteClasses(
     value = {

--- a/src/test/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotPrivateKeyCredentialsTest.java
+++ b/src/test/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotPrivateKeyCredentialsTest.java
@@ -121,7 +121,7 @@ public class GoogleRobotPrivateKeyCredentialsTest {
     assertNotNull(googleCredential);
 
     stubRequest(
-        "https://oauth2.googleapis.com/token",
+        "https://accounts.google.com/o/oauth2/token",
         HttpStatusCodes.STATUS_CODE_OK,
         "{\"access_token\":\""
             + ACCESS_TOKEN
@@ -133,7 +133,7 @@ public class GoogleRobotPrivateKeyCredentialsTest {
       assertTrue(googleCredential.refreshToken());
       assertEquals(ACCESS_TOKEN, googleCredential.getAccessToken());
     } finally {
-      verifyRequest("https://oauth2.googleapis.com/token");
+      verifyRequest("https://accounts.google.com/o/oauth2/token");
     }
   }
 
@@ -156,7 +156,7 @@ public class GoogleRobotPrivateKeyCredentialsTest {
     assertNotNull(googleCredential);
 
     stubRequest(
-        "https://oauth2.googleapis.com/token",
+        "https://accounts.google.com/o/oauth2/token",
         HttpStatusCodes.STATUS_CODE_OK,
         "{\"access_token\":\""
             + ACCESS_TOKEN
@@ -168,7 +168,7 @@ public class GoogleRobotPrivateKeyCredentialsTest {
       assertTrue(googleCredential.refreshToken());
       assertEquals(ACCESS_TOKEN, googleCredential.getAccessToken());
     } finally {
-      verifyRequest("https://oauth2.googleapis.com/token");
+      verifyRequest("https://accounts.google.com/o/oauth2/token");
     }
   }
 

--- a/src/test/java/com/google/jenkins/plugins/credentials/oauth/JsonServiceAccountConfigTestUtil.java
+++ b/src/test/java/com/google/jenkins/plugins/credentials/oauth/JsonServiceAccountConfigTestUtil.java
@@ -16,7 +16,7 @@
 package com.google.jenkins.plugins.credentials.oauth;
 
 import com.google.api.client.json.JsonGenerator;
-import com.google.api.client.json.jackson.JacksonFactory;
+import com.google.api.client.json.jackson2.JacksonFactory;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;

--- a/src/test/java/com/google/jenkins/plugins/credentials/oauth/LegacyJsonServiceAccountConfigUtil.java
+++ b/src/test/java/com/google/jenkins/plugins/credentials/oauth/LegacyJsonServiceAccountConfigUtil.java
@@ -16,7 +16,7 @@
 package com.google.jenkins.plugins.credentials.oauth;
 
 import com.google.api.client.json.JsonGenerator;
-import com.google.api.client.json.jackson.JacksonFactory;
+import com.google.api.client.json.jackson2.JacksonFactory;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;


### PR DESCRIPTION
Due to Jenkins coming bundled with guava 11, the highest version of the Google API/HTTP clients we can use is 1.24.1