### PR TITLE
Clean branch name before creating artifacts.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,7 +25,8 @@ pipeline {
     environment {
         GOOGLE_PROJECT_ID = "${OAUTH_IT_PROJECT_ID}"
         BUILD_ARTIFACTS_BUCKET = "${OAUTH_IT_BUCKET}"
-        BUILD_ARTIFACTS = "build-${BRANCH_NAME}-${BUILD_ID}.tar.gz"
+        CLEAN_BRANCH_NAME = "${BRANCH_NAME}".replaceAll("[/&;<>|\\]]", "_")
+        BUILD_ARTIFACTS = "build-${CLEAN_BRANCH_NAME}-${BUILD_ID}.tar.gz"
     }
 
     stages {


### PR DESCRIPTION
Due to using git flow, when the branch 'release/0.10' was created, this was fine as a branch name but not as part of a file name. This replaces characters that are legal in branch names but illegal in filenames in order to avoid that issue.