### PR TITLE
Fix oauth-credentials version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -145,7 +145,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>oauth-credentials</artifactId>
-      <version>0.4-beta</version>
+      <version>0.4</version>
     </dependency>
     <!-- com.google.http-client -->
     <dependency>


### PR DESCRIPTION
The `beta` version would only be available to users using the
experimental update-center. This means that a release of a
plugin with a dependency with a `beta` version will not be
_installable_ on many Jenkins instances.

sorry @craigdbarber, I wanted this to be part of #77.