### PR TITLE
MetadataReader: use correct header for metadata requests

### DIFF
--- a/src/main/java/com/google/jenkins/plugins/util/MetadataReader.java
+++ b/src/main/java/com/google/jenkins/plugins/util/MetadataReader.java
@@ -73,7 +73,7 @@ public interface MetadataReader {
 
       // GCE v1 requires requests to the metadata service to specify
       // this header in order to get anything back.
-      request.getHeaders().set("X-Google-Metadata-Request", true);
+      request.getHeaders().set("Metadata-Flavor", "Google");
 
       HttpResponse response;
       try {

--- a/src/test/java/com/google/jenkins/plugins/util/MetadataReaderTest.java
+++ b/src/test/java/com/google/jenkins/plugins/util/MetadataReaderTest.java
@@ -48,7 +48,7 @@ public class MetadataReaderTest {
   private void verifyRequest(String key) throws IOException {
     verify(transport).buildRequest("GET", METADATA_ENDPOINT + key);
     verify(request).execute();
-    assertEquals("true", getOnlyElement(request.getHeaderValues("X-Google-Metadata-Request")));
+    assertEquals("Google", getOnlyElement(request.getHeaderValues("Metadata-Flavor")));
   }
 
   private MetadataReader underTest;


### PR DESCRIPTION
According to https://cloud.google.com/compute/docs/storing-retrieving-metadata
"Metadata-Flavor: Google" is the correct header for metadata requests.

The old "X-Google-Metadata-Request: True" is not working when running in GKE
with Workload Identity and the GKE metadata server enabled.

$ curl "http://metadata/computeMetadata/v1/" -H "Metadata-Flavor: Google"
instance/
project/

$ curl "http://metadata/computeMetadata/v1/" -H "X-Google-Metadata-Request: True"
Missing required header "Metadata-Flavor": "Google"
