### PR TITLE
[JENKINS-65862] bump casc to 1.51

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
     <spotbugs.effort>Max</spotbugs.effort>
     <doclint>none</doclint>
     <runSuite>**/GoogleOAuthPluginTestSuite.class</runSuite>
-    <configuration-as-code.version>1.35</configuration-as-code.version>
+    <configuration-as-code.version>1.51</configuration-as-code.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
Resolving some PCT failures where releasing an upgraded version of `workflow-scm-step` causes a failure in `google-oauth` specifically related to upgrading `Casc` to >= 1.51

CC @alecharp 

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
