### PR TITLE
Update Google HTTP, API, and OAuth libs to much newer versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,9 +69,8 @@
   <properties>
     <jenkins.version>2.222.4</jenkins.version>
     <hpi.compatibleSinceVersion>1.0.0</hpi.compatibleSinceVersion>
-    <google.api.version>1.25.0</google.api.version>
-    <oauth2.revision>151</oauth2.revision>
-    <google.http.version>1.21.0</google.http.version>
+    <google.api.version>1.32.1</google.api.version>
+    <oauth2.revision>20200213</oauth2.revision>
     <lombok.version>1.18.18</lombok.version>
     <java.level>8</java.level>
     <spotbugs.effort>Max</spotbugs.effort>
@@ -118,6 +117,15 @@
       <!-- XStream has deserialization warnings for Jodatime 2.0 or later -->
       <version>2.10.10</version>
     </dependency>
+    <!--
+      Use a newer version of Guava, since google-http-client needs at least v14, rather than v11 bundled with Jenkins.
+      However, this usage should be masked from other consumers via the maven-hpi-plugin configuration below.
+      The exact version being used is defined by the com.google.cloud:libraries-bom
+    -->
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
     <!-- Test dependencies -->
     <dependency>
       <groupId>org.hamcrest</groupId>
@@ -155,7 +163,6 @@
     <dependency>
       <groupId>com.google.http-client</groupId>
       <artifactId>google-http-client</artifactId>
-      <version>${google.http.version}</version>
       <exclusions>
         <exclusion>
           <groupId>org.apache.httpcomponents</groupId>
@@ -170,7 +177,6 @@
     <dependency>
       <groupId>com.google.http-client</groupId>
       <artifactId>google-http-client-jackson2</artifactId>
-      <version>${google.api.version}</version>
       <exclusions>
         <exclusion>
           <groupId>com.google.http-client</groupId>
@@ -187,10 +193,6 @@
         <exclusion>
           <groupId>com.google.http-client</groupId>
           <artifactId>google-http-client</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.google.guava</groupId>
-          <artifactId>guava</artifactId>
         </exclusion>
         <exclusion>
           <groupId>com.google.code.findbugs</groupId>
@@ -249,6 +251,14 @@
 
   <build>
     <plugins>
+      <plugin>
+        <groupId>org.jenkins-ci.tools</groupId>
+        <artifactId>maven-hpi-plugin</artifactId>
+        <configuration>
+          <!-- Workaround from JENKINS-36779, since we need a custom version of Guava -->
+          <maskClasses>com.google.common.</maskClasses>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,6 @@
     <spotbugs.effort>Max</spotbugs.effort>
     <doclint>none</doclint>
     <runSuite>**/GoogleOAuthPluginTestSuite.class</runSuite>
-    <configuration-as-code.version>1.35</configuration-as-code.version>
   </properties>
 
   <dependencyManagement>
@@ -149,7 +148,6 @@
     <dependency>
       <groupId>io.jenkins</groupId>
       <artifactId>configuration-as-code</artifactId>
-      <version>${configuration-as-code.version}</version>
       <scope>test</scope>
       <!--Marked as optional so hpi:run does not include it. -->
       <optional>true</optional>
@@ -157,7 +155,6 @@
     <dependency>
       <groupId>io.jenkins.configuration-as-code</groupId>
       <artifactId>test-harness</artifactId>
-      <version>${configuration-as-code.version}</version>
       <scope>test</scope>
       <optional>true</optional>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -132,6 +132,24 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.errorprone</groupId>
+          <artifactId>error_prone_annotations</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.google.code.findbugs</groupId>
+          <artifactId>jsr305</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.google.j2objc</groupId>
+          <artifactId>j2objc-annotations</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.checkerframework</groupId>
+          <artifactId>checker-compat-qual</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <!-- Test dependencies -->
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.17</version>
+    <version>4.24</version>
   </parent>
 
   <!--
@@ -85,7 +85,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-2.222.x</artifactId>
-        <version>26</version>
+        <version>29</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,14 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <!-- Ensures version compatibility: https://googleapis.github.io/google-http-java-client/setup.html -->
+      <dependency>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>libraries-bom</artifactId>
+        <version>20.9.0</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
     </dependencies>
   </dependencyManagement>
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
     <hpi.compatibleSinceVersion>1.0.0</hpi.compatibleSinceVersion>
     <google.api.version>1.32.1</google.api.version>
     <oauth2.revision>20200213</oauth2.revision>
-    <lombok.version>1.18.18</lombok.version>
+    <lombok.version>1.18.20</lombok.version>
     <java.level>8</java.level>
     <spotbugs.effort>Max</spotbugs.effort>
     <doclint>none</doclint>

--- a/pom.xml
+++ b/pom.xml
@@ -99,9 +99,17 @@
     </dependencies>
   </dependencyManagement>
   <dependencies>
+    <!--
+      Use API plugins for oft-used transitive dependencies:
+      https://www.jenkins.io/doc/developer/plugin-development/dependencies-and-class-loading/#using-library-wrapper-plugins
+    -->
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>jackson2-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>apache-httpcomponents-client-4-api</artifactId>
     </dependency>
     <!-- Apache Commons IO dependency -->
     <dependency>


### PR DESCRIPTION
TL;DR: This updates some _really_ old dependencies, and will allow me to update my plugin which depends on this one.

---

This updates the Google HTTP client (from a version released in November 2015), the Google API client (from August 2018), and the OAuth2 library (from May 2019).

Updating these libraries seems like a good idea, and is the culmination of a yak-shaving adventure I went on in order to update the Google Play client library in my [plugin](https://github.com/jenkinsci/google-play-android-publisher-plugin), which depends on this one…

The latest Google Play client library now depends on google-http-client 1.38+, which is a problem since the older version gets class-loaded from this plugin instead (as far as I understand it), and I would get `NoClassDefFoundError`s, despite depending on 1.39.2 in my plugin.

However, newer versions of `google-http-client` depend on newer Guava versions (v14+, AFAICT) due to depending on classes like [`BaseEncoding`](https://guava.dev/releases/14.0/api/docs/com/google/common/io/BaseEncoding.html) and [`StandardSystemProperty`](https://guava.dev/releases/15.0/api/docs/com/google/common/base/StandardSystemProperty.html), and so the ancient v11 bundled with Jenkins is no use.

So despite the removal of Guava from this plugin in #114, I had to pull in a newer version again, and this time applied a workaround from [JENKINS-36779](https://issues.jenkins.io/browse/JENKINS-36779?focusedCommentId=403197&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-403197).

The automated tests still pass as before (i.e. two of them fail on JDK 8), and bundling a snapshot of this PR into the Google Play Android Publisher plugin allowed it to function as expected with the upgraded Google Play client library.

I also did some other small cleanups, which should supersede #118, #124, and #126.