### PR TITLE
Ensure Guava 11->30+ compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
 
   <!-- Bring some sanity to version numbering... -->
   <properties>
-    <jenkins.version>2.222.4</jenkins.version>
+    <jenkins.version>2.321</jenkins.version>
     <hpi.compatibleSinceVersion>1.0.0</hpi.compatibleSinceVersion>
     <google.api.version>1.25.0</google.api.version>
     <oauth2.revision>151</oauth2.revision>
@@ -84,8 +84,9 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.222.x</artifactId>
-        <version>26</version>
+        <artifactId>bom-2.249.x</artifactId>
+        <!-- TODO weekly -->
+        <version>966.v3857b7c82032</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
 
   <!-- Bring some sanity to version numbering... -->
   <properties>
-    <jenkins.version>2.321</jenkins.version>
+    <jenkins.version>2.222.4</jenkins.version>
     <hpi.compatibleSinceVersion>1.0.0</hpi.compatibleSinceVersion>
     <google.api.version>1.25.0</google.api.version>
     <oauth2.revision>151</oauth2.revision>
@@ -84,9 +84,8 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.249.x</artifactId>
-        <!-- TODO weekly -->
-        <version>966.v3857b7c82032</version>
+        <artifactId>bom-2.222.x</artifactId>
+        <version>26</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/JsonKey.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/JsonKey.java
@@ -19,12 +19,12 @@ import com.google.api.client.json.GenericJson;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.util.Key;
 import com.google.common.base.Charsets;
-import com.google.common.io.CharStreams;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.util.Secret;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import org.apache.commons.io.IOUtils;
 
 /**
  * The <a href="https://console.developers.google.com">Google Developer Console</a> provides private
@@ -52,7 +52,7 @@ public final class JsonKey extends GenericJson {
   public static JsonKey load(JsonFactory jsonFactory, InputStream inputStream) throws IOException {
     InputStreamReader reader = new InputStreamReader(inputStream, Charsets.UTF_8);
     try {
-      Secret decoded = Secret.fromString(CharStreams.toString(reader));
+      Secret decoded = Secret.fromString(IOUtils.toString(reader));
       return jsonFactory.fromString(decoded.getPlainText(), JsonKey.class);
     } finally {
       inputStream.close();

--- a/src/main/java/com/google/jenkins/plugins/util/MetadataReader.java
+++ b/src/main/java/com/google/jenkins/plugins/util/MetadataReader.java
@@ -19,7 +19,6 @@ import static com.google.api.client.http.HttpStatusCodes.STATUS_CODE_FORBIDDEN;
 import static com.google.api.client.http.HttpStatusCodes.STATUS_CODE_NOT_FOUND;
 import static com.google.api.client.http.HttpStatusCodes.STATUS_CODE_UNAUTHORIZED;
 import static com.google.common.base.Preconditions.checkNotNull;
-import static com.google.common.io.CharStreams.copy;
 
 import com.google.api.client.http.GenericUrl;
 import com.google.api.client.http.HttpRequest;
@@ -31,6 +30,7 @@ import com.google.common.base.Charsets;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.StringWriter;
+import org.apache.commons.io.IOUtils;
 
 /**
  * This helper utility is used for reading values out of a Google Compute Engine instance's attached
@@ -93,7 +93,7 @@ public interface MetadataReader {
       try (InputStreamReader inChars =
           new InputStreamReader(checkNotNull(response.getContent()), Charsets.UTF_8)) {
         StringWriter output = new StringWriter();
-        copy(inChars, output);
+        IOUtils.copy(inChars, output);
         return output.toString();
       }
     }


### PR DESCRIPTION
Replaces use of `CharStream.toString` and `CharStream.copy` with the Apache Commons IO `IOUtils.*` equivalents.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
