### PR TITLE
[JENKINS-71922] Support Java 21

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,6 @@
 buildPlugin(configurations: [
-    [ platform: "linux", jdk: "8", jenkins: null ],
     [ platform: "linux", jdk: "11", jenkins: null ],
-    [ platform: "windows", jdk: "8", jenkins: null ],
+    [ platform: "linux", jdk: "17", jenkins: null ],
+    [ platform: "linux", jdk: "21", jenkins: null ],
+    [ platform: "windows", jdk: "11", jenkins: null ],
 ])

--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,6 @@
     <configuration-as-code.version>1.19</configuration-as-code.version>
     <credentials.version>2.2.0</credentials.version>
     <java.level>8</java.level>
-    <lombok.version>1.18.24</lombok.version>
     <spotbugs.effort>Max</spotbugs.effort>
     <doclint>none</doclint>
     <runSuite>**/GoogleOAuthPluginTestSuite.class</runSuite>
@@ -270,12 +269,6 @@
       <artifactId>bouncycastle-api</artifactId>
       <version>2.20</version>
       <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.projectlombok</groupId>
-      <artifactId>lombok</artifactId>
-      <version>${lombok.version}</version>
-      <optional>true</optional>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.47</version>
+    <version>4.73</version>
   </parent>
 
   <!--
@@ -69,7 +69,7 @@
     <revision>1.0.8</revision>
     <changelist>-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/google-oauth-plugin</gitHubRepo>
-    <jenkins.version>2.319.3</jenkins.version>
+    <jenkins.version>2.361.4</jenkins.version>
     <hpi.compatibleSinceVersion>1.0.0</hpi.compatibleSinceVersion>
     <!-- TODO: Update google versions when Jenkins core does not bundle guava 11. -->
     <google.api.version>1.35.2</google.api.version>
@@ -78,7 +78,6 @@
     <google.http.version>1.21.0</google.http.version>
     <configuration-as-code.version>1.19</configuration-as-code.version>
     <credentials.version>2.2.0</credentials.version>
-    <java.level>8</java.level>
     <spotbugs.effort>Max</spotbugs.effort>
     <doclint>none</doclint>
     <runSuite>**/GoogleOAuthPluginTestSuite.class</runSuite>
@@ -88,8 +87,8 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.319.x</artifactId>
-        <version>1607.va_c1576527071</version>
+        <artifactId>bom-2.361.x</artifactId>
+        <version>2102.v854b_fec19c92</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -187,7 +186,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>oauth-credentials</artifactId>
-      <version>0.5</version>
+      <version>0.645.ve666a_c332668</version>
     </dependency>
     <!-- com.google.http-client -->
     <dependency>

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotCredentials.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotCredentials.java
@@ -28,8 +28,8 @@ import hudson.util.Secret;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.util.Collections;
+import java.util.Objects;
 import jenkins.model.Jenkins;
-import lombok.EqualsAndHashCode;
 
 /**
  * The base implementation of service account (aka robot) credentials using OAuth2. These robot
@@ -106,7 +106,6 @@ public abstract class GoogleRobotCredentials implements GoogleOAuth2Credentials 
    * A trivial tuple for wrapping the list box of matched credentials with the requirements that
    * were used to filter them.
    */
-  @EqualsAndHashCode
   public static class CredentialsListBoxModel extends ListBoxModel {
     public CredentialsListBoxModel(GoogleOAuth2ScopeRequirement requirement) {
       this.requirement = requirement;
@@ -118,6 +117,26 @@ public abstract class GoogleRobotCredentials implements GoogleOAuth2Credentials 
     }
 
     private final GoogleOAuth2ScopeRequirement requirement;
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      if (!super.equals(o)) {
+        return false;
+      }
+      CredentialsListBoxModel options = (CredentialsListBoxModel) o;
+      return Objects.equals(requirement, options.requirement);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(super.hashCode(), requirement);
+    }
   }
 
   /**


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

Related to [JENKINS-71922](https://issues.jenkins.io/browse/JENKINS-71922)

The usage of Lombok was introduced in https://github.com/jenkinsci/google-oauth-plugin/commit/5972f753b7c3b92f863f1a7c3e48f66eb604174e.
The dependency was used only to remove a few lines of code which can generally be generated by any IDE. 

There is no usages of the library outside of the `CredentialsListBoxModel` class, so it seems a bit overkill to use the library. Removing it to be compatible with Java 21 seems quicker.

### Testing done

Ran `mvn verify` with Java 21, no issue.
Ran `mvn hpi:run` using Java 21 but faced issue when trying to use the plugin in Google Compute Engine where creating a compute-engine node in Jenkins yields an issue about not finding `configure-entries.jelly` for `ComputeEngineInstance` class.


<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
