### PR TITLE
Enable creating multiple Google credentials for the same project id

### DIFF
--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotCredentials.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotCredentials.java
@@ -19,7 +19,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.cloudbees.plugins.credentials.CredentialsNameProvider;
 import com.cloudbees.plugins.credentials.CredentialsProvider;
-import com.cloudbees.plugins.credentials.common.IdCredentials;
+import com.cloudbees.plugins.credentials.impl.BaseStandardCredentials;
 import com.google.api.client.auth.oauth2.Credential;
 import com.google.common.collect.ImmutableList;
 import com.google.jenkins.plugins.credentials.domains.DomainRequirementProvider;
@@ -38,7 +38,8 @@ import jenkins.model.Jenkins;
  *
  * @author Matt Moore
  */
-public abstract class GoogleRobotCredentials implements GoogleOAuth2Credentials {
+public abstract class GoogleRobotCredentials extends BaseStandardCredentials
+    implements GoogleOAuth2Credentials {
   /**
    * Base constructor for populating the name and id for Google credentials.
    *
@@ -46,7 +47,20 @@ public abstract class GoogleRobotCredentials implements GoogleOAuth2Credentials 
    * @param module The module to use for instantiating the dependencies of credentials.
    */
   protected GoogleRobotCredentials(String projectId, GoogleRobotCredentialsModule module) {
-    this.id = IdCredentials.Helpers.fixEmptyId("");
+    this("", projectId, module);
+  }
+
+  /**
+   * Migration only constructor with a specified credential id. Do not use this, it is only for migrating
+   * old credentials that had no id and relied on the project id.
+   *
+   * @param id the credential ID to assign.
+   * @param projectId The project id with which this credential is associated.
+   * @param module The module to use for instantiating the dependencies of credentials.
+   */
+  protected GoogleRobotCredentials(
+      String id, String projectId, GoogleRobotCredentialsModule module) {
+    super(id, Messages.GoogleRobotCredentials_Description());
     this.projectId = checkNotNull(projectId);
 
     if (module != null) {
@@ -61,17 +75,7 @@ public abstract class GoogleRobotCredentials implements GoogleOAuth2Credentials 
     return module;
   }
 
-  private String id;
-
   private final GoogleRobotCredentialsModule module;
-
-  /** Retrieve a unique identifier that should be used to link to this object. */
-  public String getId() {
-    if (id == null) {
-      id = projectId; // for migrating old credentials which had no id other than project id
-    }
-    return id;
-  }
 
   /** {@inheritDoc} */
   @Override

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotCredentials.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotCredentials.java
@@ -51,8 +51,9 @@ public abstract class GoogleRobotCredentials extends BaseStandardCredentials
   }
 
   /**
-   * Migration only constructor with a specified credential id. Do not use this, it is only for migrating
-   * old credentials that had no id and relied on the project id.
+   * Base constructor for populating the name and id and project id for Google credentials. Leave
+   * the id empty to generate a new one, populate the id when updating an existing credential or
+   * migrating from using the project id as the credential id.
    *
    * @param id the credential ID to assign.
    * @param projectId The project id with which this credential is associated.
@@ -60,7 +61,7 @@ public abstract class GoogleRobotCredentials extends BaseStandardCredentials
    */
   protected GoogleRobotCredentials(
       String id, String projectId, GoogleRobotCredentialsModule module) {
-    super(id, Messages.GoogleRobotCredentials_Description());
+    super(id == null ? "" : id, Messages.GoogleRobotCredentials_Description());
     this.projectId = checkNotNull(projectId);
 
     if (module != null) {

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotCredentials.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotCredentials.java
@@ -19,6 +19,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.cloudbees.plugins.credentials.CredentialsNameProvider;
 import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.common.IdCredentials;
 import com.google.api.client.auth.oauth2.Credential;
 import com.google.common.collect.ImmutableList;
 import com.google.jenkins.plugins.credentials.domains.DomainRequirementProvider;
@@ -45,6 +46,7 @@ public abstract class GoogleRobotCredentials implements GoogleOAuth2Credentials 
    * @param module The module to use for instantiating the dependencies of credentials.
    */
   protected GoogleRobotCredentials(String projectId, GoogleRobotCredentialsModule module) {
+    this.id = IdCredentials.Helpers.fixEmptyId("");
     this.projectId = checkNotNull(projectId);
 
     if (module != null) {
@@ -59,11 +61,16 @@ public abstract class GoogleRobotCredentials implements GoogleOAuth2Credentials 
     return module;
   }
 
+  private String id;
+
   private final GoogleRobotCredentialsModule module;
 
   /** Retrieve a unique identifier that should be used to link to this object. */
   public String getId() {
-    return getProjectId();
+    if (id == null) {
+      id = projectId; // for migrating old credentials which had no id other than project id
+    }
+    return id;
   }
 
   /** {@inheritDoc} */

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotMetadataCredentials.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotMetadataCredentials.java
@@ -52,21 +52,22 @@ public final class GoogleRobotMetadataCredentials extends GoogleRobotCredentials
    * @param projectId The Pantheon project id associated with this service account
    * @param module The module for instantiating dependent objects, or null.
    */
-  @DataBoundConstructor
   public GoogleRobotMetadataCredentials(
       String projectId, @Nullable GoogleRobotMetadataCredentialsModule module) throws Exception {
-    super(projectId, module);
+    super("", projectId, module);
   }
 
   /**
-   * Construct a set of service account credentials with a specific id.
-   * Do not use this, it is only for migrating old credentials that had no id and relied on the project id.
+   * Construct a set of service account credentials with a specific id. It helps for updating
+   * credentials, as well as for migrating old credentials that had no id and relied on the project
+   * id.
    *
    * @param id the id to assign
    * @param projectId The Pantheon project id associated with this service account
    * @param module The module for instantiating dependent objects, or null.
    */
-  private GoogleRobotMetadataCredentials(
+  @DataBoundConstructor
+  public GoogleRobotMetadataCredentials(
       String id, String projectId, @Nullable GoogleRobotMetadataCredentialsModule module)
       throws Exception {
     super(id, projectId, module);

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotMetadataCredentials.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotMetadataCredentials.java
@@ -28,7 +28,6 @@ import com.google.common.collect.Lists;
 import com.google.jenkins.plugins.util.ExecutorException;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-
 import hudson.Extension;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
@@ -75,9 +74,11 @@ public final class GoogleRobotMetadataCredentials extends GoogleRobotCredentials
     super(id, projectId, module);
   }
 
-  @SuppressFBWarnings(value = "RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE",
-          justification = "for migrating older credentials that did not have a separate id field, and would really "
-                          + "have a null id when attempted to deserialize. readResolve overwrites all these nulls")
+  @SuppressFBWarnings(
+      value = "RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE",
+      justification =
+          "for migrating older credentials that did not have a separate id field, and would really "
+              + "have a null id when attempted to deserialize. readResolve overwrites these nulls")
   private Object readResolve() throws Exception {
     return new GoogleRobotMetadataCredentials(
         getId() == null ? getProjectId() : getId(), getProjectId(), getModule());

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotMetadataCredentials.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotMetadataCredentials.java
@@ -27,6 +27,8 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.jenkins.plugins.util.ExecutorException;
 import edu.umd.cs.findbugs.annotations.Nullable;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import hudson.Extension;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
@@ -73,6 +75,9 @@ public final class GoogleRobotMetadataCredentials extends GoogleRobotCredentials
     super(id, projectId, module);
   }
 
+  @SuppressFBWarnings(value = "RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE",
+          justification = "for migrating older credentials that did not have a separate id field, and would really "
+                          + "have a null id when attempted to deserialize. readResolve overwrites all these nulls")
   private Object readResolve() throws Exception {
     return new GoogleRobotMetadataCredentials(
         getId() == null ? getProjectId() : getId(), getProjectId(), getModule());

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotMetadataCredentials.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotMetadataCredentials.java
@@ -58,6 +58,25 @@ public final class GoogleRobotMetadataCredentials extends GoogleRobotCredentials
     super(projectId, module);
   }
 
+  /**
+   * Construct a set of service account credentials with a specific id.
+   * Do not use this, it is only for migrating old credentials that had no id and relied on the project id.
+   *
+   * @param id the id to assign
+   * @param projectId The Pantheon project id associated with this service account
+   * @param module The module for instantiating dependent objects, or null.
+   */
+  private GoogleRobotMetadataCredentials(
+      String id, String projectId, @Nullable GoogleRobotMetadataCredentialsModule module)
+      throws Exception {
+    super(id, projectId, module);
+  }
+
+  private Object readResolve() throws Exception {
+    return new GoogleRobotMetadataCredentials(
+        getId() == null ? getProjectId() : getId(), getProjectId(), getModule());
+  }
+
   /** {@inheritDoc} */
   @Override
   public GoogleRobotMetadataCredentialsModule getModule() {

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotPrivateKeyCredentials.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotPrivateKeyCredentials.java
@@ -23,6 +23,8 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import hudson.Extension;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -86,6 +88,9 @@ public final class GoogleRobotPrivateKeyCredentials extends GoogleRobotCredentia
   }
 
   @SuppressWarnings("deprecation")
+  @SuppressFBWarnings(value = "RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE",
+          justification = "for migrating older credentials that did not have a separate id field, and would really "
+                          + "have a null id when attempted to deserialize. readResolve overwrites all these nulls")
   public Object readResolve() throws Exception {
     if (serviceAccountConfig == null) {
       String clientEmail = getClientEmailFromSecretsFileAndLogErrors();

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotPrivateKeyCredentials.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotPrivateKeyCredentials.java
@@ -56,25 +56,26 @@ public final class GoogleRobotPrivateKeyCredentials extends GoogleRobotCredentia
    * @param serviceAccountConfig The ServiceAccountConfig to use
    * @param module The module for instantiating dependent objects, or null.
    */
-  @DataBoundConstructor
   public GoogleRobotPrivateKeyCredentials(
       String projectId,
       ServiceAccountConfig serviceAccountConfig,
       @Nullable GoogleRobotCredentialsModule module)
       throws Exception {
-    super(projectId, module);
+    super("", projectId, module);
     this.serviceAccountConfig = serviceAccountConfig;
   }
 
   /**
-   * Construct a set of service account credentials with a specific id. Do not use this, it is only for migrating
-   * old credentials that had no id and relied on the project id.
+   * Construct a set of service account credentials with a specific id. It helps for updating
+   * credentials, as well as for migrating old credentials that had no id and relied on the project
+   * id.
    *
    * @param projectId The project id associated with this service account
    * @param serviceAccountConfig The ServiceAccountConfig to use
    * @param module The module for instantiating dependent objects, or null.
    */
-  private GoogleRobotPrivateKeyCredentials(
+  @DataBoundConstructor
+  public GoogleRobotPrivateKeyCredentials(
       String id,
       String projectId,
       ServiceAccountConfig serviceAccountConfig,

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotPrivateKeyCredentials.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotPrivateKeyCredentials.java
@@ -66,13 +66,35 @@ public final class GoogleRobotPrivateKeyCredentials extends GoogleRobotCredentia
     this.serviceAccountConfig = serviceAccountConfig;
   }
 
+  /**
+   * Construct a set of service account credentials with a specific id. Do not use this, it is only for migrating
+   * old credentials that had no id and relied on the project id.
+   *
+   * @param projectId The project id associated with this service account
+   * @param serviceAccountConfig The ServiceAccountConfig to use
+   * @param module The module for instantiating dependent objects, or null.
+   */
+  private GoogleRobotPrivateKeyCredentials(
+      String id,
+      String projectId,
+      ServiceAccountConfig serviceAccountConfig,
+      @Nullable GoogleRobotCredentialsModule module)
+      throws Exception {
+    super(id, projectId, module);
+    this.serviceAccountConfig = serviceAccountConfig;
+  }
+
   @SuppressWarnings("deprecation")
-  public Object readResolve() {
+  public Object readResolve() throws Exception {
     if (serviceAccountConfig == null) {
       String clientEmail = getClientEmailFromSecretsFileAndLogErrors();
       serviceAccountConfig = new P12ServiceAccountConfig(clientEmail, null, p12File);
     }
-    return this;
+    return new GoogleRobotPrivateKeyCredentials(
+        getId() == null ? getProjectId() : getId(),
+        getProjectId(),
+        serviceAccountConfig,
+        getModule());
   }
 
   private String getClientEmailFromSecretsFileAndLogErrors() {

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotPrivateKeyCredentials.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotPrivateKeyCredentials.java
@@ -24,7 +24,6 @@ import com.google.common.collect.ImmutableList;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-
 import hudson.Extension;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -88,9 +87,11 @@ public final class GoogleRobotPrivateKeyCredentials extends GoogleRobotCredentia
   }
 
   @SuppressWarnings("deprecation")
-  @SuppressFBWarnings(value = "RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE",
-          justification = "for migrating older credentials that did not have a separate id field, and would really "
-                          + "have a null id when attempted to deserialize. readResolve overwrites all these nulls")
+  @SuppressFBWarnings(
+      value = "RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE",
+      justification =
+          "for migrating older credentials that did not have a separate id field, and would really "
+              + "have a null id when attempted to deserialize. readResolve overwrites these nulls")
   public Object readResolve() throws Exception {
     if (serviceAccountConfig == null) {
       String clientEmail = getClientEmailFromSecretsFileAndLogErrors();

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/RemotableGoogleCredentials.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/RemotableGoogleCredentials.java
@@ -91,9 +91,11 @@ final class RemotableGoogleCredentials extends GoogleRobotCredentials {
     this.expiration = expiration;
   }
 
-  @SuppressFBWarnings(value = "RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE",
-          justification = "for migrating older credentials that did not have a separate id field, and would really "
-                          + "have a null id when attempted to deserialize. readResolve overwrites all these nulls")
+  @SuppressFBWarnings(
+      value = "RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE",
+      justification =
+          "for migrating older credentials that did not have a separate id field, and would really "
+              + "have a null id when attempted to deserialize. readResolve overwrites these nulls")
   private Object readResolve() throws Exception {
     return new RemotableGoogleCredentials(
         getId() == null ? getProjectId() : getId(),

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/RemotableGoogleCredentials.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/RemotableGoogleCredentials.java
@@ -91,6 +91,9 @@ final class RemotableGoogleCredentials extends GoogleRobotCredentials {
     this.expiration = expiration;
   }
 
+  @SuppressFBWarnings(value = "RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE",
+          justification = "for migrating older credentials that did not have a separate id field, and would really "
+                          + "have a null id when attempted to deserialize. readResolve overwrites all these nulls")
   private Object readResolve() throws Exception {
     return new RemotableGoogleCredentials(
         getId() == null ? getProjectId() : getId(),

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/RemotableGoogleCredentials.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/RemotableGoogleCredentials.java
@@ -51,7 +51,7 @@ final class RemotableGoogleCredentials extends GoogleRobotCredentials {
       GoogleOAuth2ScopeRequirement requirement,
       GoogleRobotCredentialsModule module)
       throws GeneralSecurityException {
-    super(checkNotNull(credentials).getProjectId(), checkNotNull(module));
+    super("", checkNotNull(credentials).getProjectId(), checkNotNull(module));
 
     this.username = credentials.getUsername();
 

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/RemotableGoogleCredentials.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/RemotableGoogleCredentials.java
@@ -74,6 +74,32 @@ final class RemotableGoogleCredentials extends GoogleRobotCredentials {
             .plusSeconds(checkNotNull(credential.getExpiresInSeconds()).intValue())
             .getMillis();
   }
+  /**
+   * Construct a remotable credential. This should never be used directly - this constructor is only
+   * for migrating old credentials that had no id and relied on the projectId during readResolve().
+   */
+  private RemotableGoogleCredentials(
+      String id,
+      String projectId,
+      GoogleRobotCredentialsModule module,
+      String username,
+      String accessToken,
+      long expiration) {
+    super(id, projectId, module);
+    this.username = username;
+    this.accessToken = accessToken;
+    this.expiration = expiration;
+  }
+
+  private Object readResolve() throws Exception {
+    return new RemotableGoogleCredentials(
+        getId() == null ? getProjectId() : getId(),
+        getProjectId(),
+        getModule(),
+        username,
+        accessToken,
+        expiration);
+  }
 
   /** {@inheritDoc} */
   @Override

--- a/src/main/resources/com/google/jenkins/plugins/credentials/oauth/GoogleRobotMetadataCredentials/config.jelly
+++ b/src/main/resources/com/google/jenkins/plugins/credentials/oauth/GoogleRobotMetadataCredentials/config.jelly
@@ -19,7 +19,7 @@
    <f:entry title="${%Project Name}" field="projectId">
      <f:textbox default="${descriptor.defaultProject()}" />
    </f:entry>
-   <input type="hidden" name="id" value="${it.id}" />
+   <input type="hidden" name="id" value="${instance.id}" />
    <f:description>
      <b>${%NOTE:}</b> ${%This instance is limited to accessing:}
      <ul>

--- a/src/main/resources/com/google/jenkins/plugins/credentials/oauth/GoogleRobotMetadataCredentials/config.jelly
+++ b/src/main/resources/com/google/jenkins/plugins/credentials/oauth/GoogleRobotMetadataCredentials/config.jelly
@@ -19,6 +19,7 @@
    <f:entry title="${%Project Name}" field="projectId">
      <f:textbox default="${descriptor.defaultProject()}" />
    </f:entry>
+   <input type="hidden" name="id" value="${it.id}" />
    <f:description>
      <b>${%NOTE:}</b> ${%This instance is limited to accessing:}
      <ul>

--- a/src/main/resources/com/google/jenkins/plugins/credentials/oauth/GoogleRobotPrivateKeyCredentials/config.jelly
+++ b/src/main/resources/com/google/jenkins/plugins/credentials/oauth/GoogleRobotPrivateKeyCredentials/config.jelly
@@ -21,6 +21,7 @@
   <!-- When Jenkins is running outside of GCE, they are forced to utilize
        explicit credentials -->
   <input type="hidden" name="explicitCredentials" value="true" />
+  <input type="hidden" name="id" value="${instance.id}" />
   <j:set value="${instance.serviceAccountConfig}"
          var="currentServiceAccountConfig"/>
   <j:invokeStatic className="com.google.jenkins.plugins.credentials.oauth.GoogleRobotPrivateKeyCredentials"

--- a/src/test/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotCredentialsTest.java
+++ b/src/test/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotCredentialsTest.java
@@ -68,7 +68,7 @@ public class GoogleRobotCredentialsTest {
   @RequiresDomain(value = TestRequirement.class)
   public static class FakeGoogleCredentials extends GoogleRobotCredentials {
     public FakeGoogleCredentials(String projectId, GoogleCredential credential) {
-      super(projectId, new GoogleRobotCredentialsModule());
+      super("", projectId, new GoogleRobotCredentialsModule());
 
       this.credential = credential;
     }
@@ -126,13 +126,6 @@ public class GoogleRobotCredentialsTest {
     assertNotNull(credentials.getId());
     assertSame(fakeCredential, credentials.getGoogleCredential(null));
     assertEquals(Messages.GoogleRobotCredentials_Description(), credentials.getDescription());
-  }
-
-  @Test
-  @WithoutJenkins
-  public void testWithId() throws Exception {
-    FakeGoogleCredentials credentials = new FakeGoogleCredentials(PROJECT_ID, fakeCredential);
-    assertEquals(PROJECT_ID, credentials.getId());
   }
 
   @Test

--- a/src/test/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotCredentialsTest.java
+++ b/src/test/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotCredentialsTest.java
@@ -17,6 +17,7 @@ package com.google.jenkins.plugins.credentials.oauth;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
@@ -40,6 +41,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.WithoutJenkins;
+import org.jvnet.hudson.test.recipes.LocalData;
 import org.mockito.MockitoAnnotations;
 
 /** Tests for {@link GoogleRobotCredentials}. */
@@ -208,10 +210,26 @@ public class GoogleRobotCredentialsTest {
     assertNull(GoogleRobotCredentials.getById("not an id"));
   }
 
+  @LocalData
+  @Test
+  public void testMigration() {
+    /* LocalData contains an old credential with no id field and the project id my-google-project.
+    On deserialization the id should be filled with the project id. */
+    assertNotNull(GoogleRobotCredentials.getById(MIGRATION_PROJECT_ID));
+  }
+
+  @Test
+  public void testMultipleCredentials() {
+    FakeGoogleCredentials credential1 = new FakeGoogleCredentials(PROJECT_ID, null);
+    FakeGoogleCredentials credential2 = new FakeGoogleCredentials(PROJECT_ID, null);
+    assertNotEquals(credential1, credential2);
+  }
+
   private static final String NAME = "my credential name";
   private static final String FAKE_SCOPE = "my.fake.scope";
   private static final String DISPLAY_NAME = "blah";
   private static final String PROJECT_ID = "foo.com:bar-baz";
+  private static final String MIGRATION_PROJECT_ID = "my-google-project";
   private static final String USERNAME = "mattomata";
   private static final String ACCESS_TOKEN = "ThE.ToKeN";
   private static final long EXPIRATION_SECONDS = 1234;

--- a/src/test/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotMetadataCredentialsTest.java
+++ b/src/test/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotMetadataCredentialsTest.java
@@ -109,20 +109,6 @@ public class GoogleRobotMetadataCredentialsTest {
 
   @Test
   @WithoutJenkins
-  public void basicRoundtripTest() throws Exception {
-    final Module module = new Module();
-    GoogleRobotMetadataCredentials newCreds =
-        new GoogleRobotMetadataCredentials(PROJECT_ID, module);
-
-    GoogleRobotMetadataCredentials updateCreds =
-        new GoogleRobotMetadataCredentials(newCreds.getProjectId(), module);
-
-    assertEquals(newCreds.getId(), updateCreds.getId());
-    assertEquals(newCreds.getProjectId(), updateCreds.getProjectId());
-  }
-
-  @Test
-  @WithoutJenkins
   public void accessTokenTest() throws Exception {
     final Module module = new Module();
 

--- a/src/test/resources/com/google/jenkins/plugins/credentials/oauth/GoogleRobotCredentialsTest/testMigration/credentials.xml
+++ b/src/test/resources/com/google/jenkins/plugins/credentials/oauth/GoogleRobotCredentialsTest/testMigration/credentials.xml
@@ -1,0 +1,17 @@
+<?xml version='1.1' encoding='UTF-8'?>
+<com.cloudbees.plugins.credentials.SystemCredentialsProvider plugin="credentials@1189.vf61b_a_5e2f62e">
+  <domainCredentialsMap class="hudson.util.CopyOnWriteMap$Hash">
+    <entry>
+      <com.cloudbees.plugins.credentials.domains.Domain>
+        <specifications/>
+      </com.cloudbees.plugins.credentials.domains.Domain>
+      <java.util.concurrent.CopyOnWriteArrayList>
+        <com.google.jenkins.plugins.credentials.oauth.GoogleRobotPrivateKeyCredentials plugin="google-oauth-plugin@1.0.12-SNAPSHOT">
+          <module/>
+          <projectId>my-google-project</projectId>
+          <serviceAccountConfig class="com.google.jenkins.plugins.credentials.oauth.JsonServiceAccountConfig"/>
+        </com.google.jenkins.plugins.credentials.oauth.GoogleRobotPrivateKeyCredentials>
+      </java.util.concurrent.CopyOnWriteArrayList>
+    </entry>
+  </domainCredentialsMap>
+</com.cloudbees.plugins.credentials.SystemCredentialsProvider>


### PR DESCRIPTION
Enable an ID for GoogleRobotCredentials that is separate from the project ID and migrate the old credentials by backfilling their IDs to the project name, so that the `getId()` result for them is the same as before.
This is needed, for example, when you want to create credentials for 2 different service accounts coming from the same GCP project.
I wanted to extend `BaseStandardCredentials` for this but as their id was `NonNull`, private and final, I could not rewrite a null ID or account for a null ID in `getId()` to return the project ID instead.

<!-- Please describe your pull request here. -->

### Testing done
I created a Google Service Account from private key credential with the plugin before the change, then kept that jenkins home. I ran it after my changes and viewed the credentials, saw that the ID populated correctly, tried to create a new credential for the same project, saw it succeed and get a random id.
Added an automated test to check the credential migration and another automated test showing we can indeed create two different credentials in the same project. Removed the test to check that the id matches the project id and the test to check that creating a credential in the same project updates the old one, as neither is the now desired behavior.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
