### PR TITLE
Add scope to credentials

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,17 +16,20 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
+
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
     <version>4.73</version>
   </parent>
+
   <!--
       Lots of boilerplate from: https://wiki.jenkins-ci.org/display/JENKINS/Hosting+Plugins
   -->
   <artifactId>google-oauth-plugin</artifactId>
   <version>1.0.12-SNAPSHOT</version>
   <packaging>hpi</packaging>
+
   <name>Google OAuth Credentials plugin</name>
   <url>https://github.com/jenkinsci/google-oauth-plugin/blob/develop/docs/home.md</url>
   <licenses>
@@ -36,6 +39,7 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
+
   <developers>
     <developer>
       <id>astroilov</id>
@@ -52,12 +56,14 @@
       <email>stephenshank@google.com</email>
     </developer>
   </developers>
+
   <scm>
     <connection>scm:git:https://github.com/${gitHubRepo}.git</connection>
     <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
     <url>https://github.com/${gitHubRepo}</url>
     <tag>google-oauth-plugin-1.0.9</tag>
   </scm>
+
   <!-- Bring some sanity to version numbering... -->
   <properties>
     <revision>1.0.8</revision>
@@ -76,6 +82,7 @@
     <doclint>none</doclint>
     <runSuite>**/GoogleOAuthPluginTestSuite.class</runSuite>
   </properties>
+
   <dependencyManagement>
     <dependencies>
       <dependency>
@@ -179,7 +186,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>oauth-credentials</artifactId>
-      <version>0.646.v02b_66dc03d2e</version>
+      <version>0.645.ve666a_c332668</version>
     </dependency>
     <!-- com.google.http-client -->
     <dependency>
@@ -252,8 +259,7 @@
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>credentials</artifactId>
     </dependency>
-    <dependency>
-      <!-- Required to run P12ServiceAccountConfigTestUtil-dependent tests against newer Jenkins core versions.
+    <dependency><!-- Required to run P12ServiceAccountConfigTestUtil-dependent tests against newer Jenkins core versions.
            Dependency on it does not cause issues in the baseline core even though the plugin is formally incompatible.
            Should it break at some point, the core requirement can be bumped to 2.17.x.
            The BC library can be also shaded if the core requirement needs to be retained.
@@ -264,6 +270,7 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
   <repositories>
     <repository>
       <id>repo.jenkins-ci.org</id>
@@ -276,6 +283,7 @@
       <url>https://repo.jenkins-ci.org/public/</url>
     </pluginRepository>
   </pluginRepositories>
+
   <build>
     <plugins>
       <plugin>
@@ -395,6 +403,7 @@
       </plugin>
     </plugins>
   </build>
+
   <reporting>
     <plugins>
       <plugin>

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotCredentials.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotCredentials.java
@@ -19,10 +19,12 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.cloudbees.plugins.credentials.CredentialsNameProvider;
 import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.CredentialsScope;
 import com.cloudbees.plugins.credentials.impl.BaseStandardCredentials;
 import com.google.api.client.auth.oauth2.Credential;
 import com.google.common.collect.ImmutableList;
 import com.google.jenkins.plugins.credentials.domains.DomainRequirementProvider;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import hudson.security.ACL;
 import hudson.util.ListBoxModel;
 import hudson.util.Secret;
@@ -40,15 +42,6 @@ import jenkins.model.Jenkins;
  */
 public abstract class GoogleRobotCredentials extends BaseStandardCredentials
     implements GoogleOAuth2Credentials {
-  /**
-   * Base constructor for populating the name and id for Google credentials.
-   *
-   * @param projectId The project id with which this credential is associated.
-   * @param module The module to use for instantiating the dependencies of credentials.
-   */
-  protected GoogleRobotCredentials(String projectId, GoogleRobotCredentialsModule module) {
-    this("", projectId, module);
-  }
 
   /**
    * Base constructor for populating the name and id and project id for Google credentials. Leave
@@ -60,10 +53,13 @@ public abstract class GoogleRobotCredentials extends BaseStandardCredentials
    * @param module The module to use for instantiating the dependencies of credentials.
    */
   protected GoogleRobotCredentials(
-      String id, String projectId, GoogleRobotCredentialsModule module) {
-    super(id == null ? "" : id, Messages.GoogleRobotCredentials_Description());
+      @CheckForNull CredentialsScope scope,
+      String id,
+      String projectId,
+      GoogleRobotCredentialsModule module) {
+    super(scope, id == null ? "" : id, Messages.GoogleRobotCredentials_Description());
+    this.scope = scope;
     this.projectId = checkNotNull(projectId);
-
     if (module != null) {
       this.module = module;
     } else {
@@ -211,5 +207,10 @@ public abstract class GoogleRobotCredentials extends BaseStandardCredentials
     return projectId;
   }
 
+  public CredentialsScope getCredentialsScope() {
+    return scope;
+  }
+
   private final String projectId;
+  private final CredentialsScope scope;
 }

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotCredentials.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotCredentials.java
@@ -44,6 +44,17 @@ public abstract class GoogleRobotCredentials extends BaseStandardCredentials
     implements GoogleOAuth2Credentials {
 
   /**
+   * Base constructor for populating the name and id for Google credentials.
+   *
+   * @param projectId The project id with which this credential is associated.
+   * @param module The module to use for instantiating the dependencies of credentials.
+   */
+  @Deprecated
+  protected GoogleRobotCredentials(String projectId, GoogleRobotCredentialsModule module) {
+    this(CredentialsScope.GLOBAL, "", projectId, module);
+  }
+
+  /**
    * Base constructor for populating the scope, name, id, and project id for Google credentials.
    * Leave the id empty to generate a new one, populate the id when updating an existing credential
    * or migrating from using the project id as the credential id. Use the scope to define the extent

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotCredentials.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotCredentials.java
@@ -44,11 +44,14 @@ public abstract class GoogleRobotCredentials extends BaseStandardCredentials
     implements GoogleOAuth2Credentials {
 
   /**
-   * Base constructor for populating the name and id and project id for Google credentials. Leave
-   * the id empty to generate a new one, populate the id when updating an existing credential or
-   * migrating from using the project id as the credential id.
+   * Base constructor for populating the scope, name, id, and project id for Google credentials.
+   * Leave the id empty to generate a new one, populate the id when updating an existing credential
+   * or migrating from using the project id as the credential id. Use the scope to define the extent
+   * to which these credentials are available within Jenkins (i.e., GLOBAL or SYSTEM).
    *
-   * @param id the credential ID to assign.
+   * @param scope The scope of the credentials, determining where they can be used in Jenkins. Can
+   *     be either GLOBAL or SYSTEM.
+   * @param id The credential ID to assign.
    * @param projectId The project id with which this credential is associated.
    * @param module The module to use for instantiating the dependencies of credentials.
    */
@@ -58,7 +61,6 @@ public abstract class GoogleRobotCredentials extends BaseStandardCredentials
       String projectId,
       GoogleRobotCredentialsModule module) {
     super(scope, id == null ? "" : id, Messages.GoogleRobotCredentials_Description());
-    this.scope = scope;
     this.projectId = checkNotNull(projectId);
     if (module != null) {
       this.module = module;
@@ -207,10 +209,5 @@ public abstract class GoogleRobotCredentials extends BaseStandardCredentials
     return projectId;
   }
 
-  public CredentialsScope getCredentialsScope() {
-    return scope;
-  }
-
   private final String projectId;
-  private final CredentialsScope scope;
 }

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotMetadataCredentials.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotMetadataCredentials.java
@@ -71,9 +71,10 @@ public final class GoogleRobotMetadataCredentials extends GoogleRobotCredentials
   @SuppressFBWarnings(
       value = "RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE",
       justification =
-          "For migration purposes: older credentials might not have had separate id or scope fields. "
-              + "These fields might be null when deserializing. The readResolve method sets defaults for "
-              + "null id and scope. Id defaults to getProjectId() and scope defaults to CredentialsScope.GLOBAL if null.")
+          "For migration purposes: older credentials might not have had separate id or "
+              + "scope fields. These fields might be null when deserializing. The readResolve "
+              + "method sets defaults for null id and scope. Id defaults to getProjectId() and "
+              + "scope defaults to CredentialsScope.GLOBAL if null.")
   private Object readResolve() throws Exception {
     return new GoogleRobotMetadataCredentials(
         getScope() == null ? CredentialsScope.GLOBAL : getScope(),

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotMetadataCredentials.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotMetadataCredentials.java
@@ -50,6 +50,18 @@ public final class GoogleRobotMetadataCredentials extends GoogleRobotCredentials
     implements DomainRestrictedCredentials {
 
   /**
+   * Construct a set of service account credentials.
+   *
+   * @param projectId The Pantheon project id associated with this service account
+   * @param module The module for instantiating dependent objects, or null.
+   */
+  @Deprecated
+  public GoogleRobotMetadataCredentials(
+          String projectId, @Nullable GoogleRobotMetadataCredentialsModule module) throws Exception {
+    super(CredentialsScope.GLOBAL, "", projectId, module);
+  }
+
+  /**
    * Construct a set of service account credentials with a specific id. It helps for updating
    * credentials, as well as for migrating old credentials that had no id and relied on the project
    * id.

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotMetadataCredentials.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotMetadataCredentials.java
@@ -71,11 +71,12 @@ public final class GoogleRobotMetadataCredentials extends GoogleRobotCredentials
   @SuppressFBWarnings(
       value = "RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE",
       justification =
-          "for migrating older credentials that did not have a separate id field, and would really "
-              + "have a null id when attempted to deserialize. readResolve overwrites these nulls")
+          "For migration purposes: older credentials might not have had separate id or scope fields. "
+              + "These fields might be null when deserializing. The readResolve method sets defaults for "
+              + "null id and scope. Id defaults to getProjectId() and scope defaults to CredentialsScope.GLOBAL if null.")
   private Object readResolve() throws Exception {
     return new GoogleRobotMetadataCredentials(
-        getCredentialsScope() == null ? CredentialsScope.GLOBAL : getCredentialsScope(),
+        getScope() == null ? CredentialsScope.GLOBAL : getScope(),
         getId() == null ? getProjectId() : getId(),
         getProjectId(),
         getModule());
@@ -120,12 +121,6 @@ public final class GoogleRobotMetadataCredentials extends GoogleRobotCredentials
    * account.
    */
   private static final String IDENTITY_PATH = "/instance/service-accounts/default/email";
-
-  /** {@inheritDoc} */
-  @Override
-  public CredentialsScope getScope() {
-    return getCredentialsScope();
-  }
 
   /** {@inheritDoc} */
   @Override

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotMetadataCredentials.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotMetadataCredentials.java
@@ -26,6 +26,7 @@ import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.jenkins.plugins.util.ExecutorException;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
@@ -47,16 +48,6 @@ import org.kohsuke.stapler.DataBoundConstructor;
 @NameWith(value = GoogleRobotNameProvider.class, priority = 50)
 public final class GoogleRobotMetadataCredentials extends GoogleRobotCredentials
     implements DomainRestrictedCredentials {
-  /**
-   * Construct a set of service account credentials.
-   *
-   * @param projectId The Pantheon project id associated with this service account
-   * @param module The module for instantiating dependent objects, or null.
-   */
-  public GoogleRobotMetadataCredentials(
-      String projectId, @Nullable GoogleRobotMetadataCredentialsModule module) throws Exception {
-    super("", projectId, module);
-  }
 
   /**
    * Construct a set of service account credentials with a specific id. It helps for updating
@@ -69,9 +60,12 @@ public final class GoogleRobotMetadataCredentials extends GoogleRobotCredentials
    */
   @DataBoundConstructor
   public GoogleRobotMetadataCredentials(
-      String id, String projectId, @Nullable GoogleRobotMetadataCredentialsModule module)
+      @CheckForNull CredentialsScope scope,
+      String id,
+      String projectId,
+      @Nullable GoogleRobotMetadataCredentialsModule module)
       throws Exception {
-    super(id, projectId, module);
+    super(scope, id, projectId, module);
   }
 
   @SuppressFBWarnings(
@@ -81,7 +75,10 @@ public final class GoogleRobotMetadataCredentials extends GoogleRobotCredentials
               + "have a null id when attempted to deserialize. readResolve overwrites these nulls")
   private Object readResolve() throws Exception {
     return new GoogleRobotMetadataCredentials(
-        getId() == null ? getProjectId() : getId(), getProjectId(), getModule());
+        getCredentialsScope() == null ? CredentialsScope.GLOBAL : getCredentialsScope(),
+        getId() == null ? getProjectId() : getId(),
+        getProjectId(),
+        getModule());
   }
 
   /** {@inheritDoc} */
@@ -127,7 +124,7 @@ public final class GoogleRobotMetadataCredentials extends GoogleRobotCredentials
   /** {@inheritDoc} */
   @Override
   public CredentialsScope getScope() {
-    return CredentialsScope.GLOBAL;
+    return getCredentialsScope();
   }
 
   /** {@inheritDoc} */

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotPrivateKeyCredentials.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotPrivateKeyCredentials.java
@@ -76,15 +76,16 @@ public final class GoogleRobotPrivateKeyCredentials extends GoogleRobotCredentia
   @SuppressFBWarnings(
       value = "RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE",
       justification =
-          "for migrating older credentials that did not have a separate id field, and would really "
-              + "have a null id when attempted to deserialize. readResolve overwrites these nulls")
+          "For migration purposes: older credentials might not have had separate id or scope fields. "
+              + "These fields might be null when deserializing. The readResolve method sets defaults for "
+              + "null id and scope. Id defaults to getProjectId() and scope defaults to CredentialsScope.GLOBAL if null.")
   public Object readResolve() throws Exception {
     if (serviceAccountConfig == null) {
       String clientEmail = getClientEmailFromSecretsFileAndLogErrors();
       serviceAccountConfig = new P12ServiceAccountConfig(clientEmail, null, p12File);
     }
     return new GoogleRobotPrivateKeyCredentials(
-        getCredentialsScope() == null ? CredentialsScope.GLOBAL : getCredentialsScope(),
+        getScope() == null ? CredentialsScope.GLOBAL : getScope(),
         getId() == null ? getProjectId() : getId(),
         getProjectId(),
         serviceAccountConfig,
@@ -184,11 +185,6 @@ public final class GoogleRobotPrivateKeyCredentials extends GoogleRobotCredentia
     return Jenkins.get()
         .getDescriptorOrDie(GoogleRobotPrivateKeyCredentials.class)
         .getHelpFile("credentials");
-  }
-
-  @Override
-  public CredentialsScope getScope() {
-    return getCredentialsScope();
   }
 
   @Override

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotPrivateKeyCredentials.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotPrivateKeyCredentials.java
@@ -76,9 +76,10 @@ public final class GoogleRobotPrivateKeyCredentials extends GoogleRobotCredentia
   @SuppressFBWarnings(
       value = "RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE",
       justification =
-          "For migration purposes: older credentials might not have had separate id or scope fields. "
-              + "These fields might be null when deserializing. The readResolve method sets defaults for "
-              + "null id and scope. Id defaults to getProjectId() and scope defaults to CredentialsScope.GLOBAL if null.")
+          "For migration purposes: older credentials might not have had separate id or "
+              + "scope fields. These fields might be null when deserializing. The readResolve "
+              + "method sets defaults for null id and scope. Id defaults to getProjectId() and "
+              + "scope defaults to CredentialsScope.GLOBAL if null.")
   public Object readResolve() throws Exception {
     if (serviceAccountConfig == null) {
       String clientEmail = getClientEmailFromSecretsFileAndLogErrors();

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotPrivateKeyCredentials.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotPrivateKeyCredentials.java
@@ -51,6 +51,24 @@ public final class GoogleRobotPrivateKeyCredentials extends GoogleRobotCredentia
   @Deprecated private transient String secretsFile;
   @Deprecated private transient String p12File;
 
+  
+  /**
+   * Construct a set of service account credentials.
+   *
+   * @param projectId The project id associated with this service account
+   * @param serviceAccountConfig The ServiceAccountConfig to use
+   * @param module The module for instantiating dependent objects, or null.
+   */
+  @Deprecated
+  public GoogleRobotPrivateKeyCredentials(
+          String projectId,
+          ServiceAccountConfig serviceAccountConfig,
+          @Nullable GoogleRobotCredentialsModule module)
+          throws Exception {
+    super(CredentialsScope.GLOBAL, "", projectId, module);
+    this.serviceAccountConfig = serviceAccountConfig;
+  }
+
   /**
    * Construct a set of service account credentials with a specific id. It helps for updating
    * credentials, as well as for migrating old credentials that had no id and relied on the project

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotPrivateKeyCredentials.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotPrivateKeyCredentials.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.core.JsonParseException;
 import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -51,22 +52,6 @@ public final class GoogleRobotPrivateKeyCredentials extends GoogleRobotCredentia
   @Deprecated private transient String p12File;
 
   /**
-   * Construct a set of service account credentials.
-   *
-   * @param projectId The project id associated with this service account
-   * @param serviceAccountConfig The ServiceAccountConfig to use
-   * @param module The module for instantiating dependent objects, or null.
-   */
-  public GoogleRobotPrivateKeyCredentials(
-      String projectId,
-      ServiceAccountConfig serviceAccountConfig,
-      @Nullable GoogleRobotCredentialsModule module)
-      throws Exception {
-    super("", projectId, module);
-    this.serviceAccountConfig = serviceAccountConfig;
-  }
-
-  /**
    * Construct a set of service account credentials with a specific id. It helps for updating
    * credentials, as well as for migrating old credentials that had no id and relied on the project
    * id.
@@ -77,12 +62,13 @@ public final class GoogleRobotPrivateKeyCredentials extends GoogleRobotCredentia
    */
   @DataBoundConstructor
   public GoogleRobotPrivateKeyCredentials(
+      @CheckForNull CredentialsScope scope,
       String id,
       String projectId,
       ServiceAccountConfig serviceAccountConfig,
       @Nullable GoogleRobotCredentialsModule module)
       throws Exception {
-    super(id, projectId, module);
+    super(scope, id, projectId, module);
     this.serviceAccountConfig = serviceAccountConfig;
   }
 
@@ -98,6 +84,7 @@ public final class GoogleRobotPrivateKeyCredentials extends GoogleRobotCredentia
       serviceAccountConfig = new P12ServiceAccountConfig(clientEmail, null, p12File);
     }
     return new GoogleRobotPrivateKeyCredentials(
+        getCredentialsScope() == null ? CredentialsScope.GLOBAL : getCredentialsScope(),
         getId() == null ? getProjectId() : getId(),
         getProjectId(),
         serviceAccountConfig,
@@ -201,7 +188,7 @@ public final class GoogleRobotPrivateKeyCredentials extends GoogleRobotCredentia
 
   @Override
   public CredentialsScope getScope() {
-    return CredentialsScope.GLOBAL;
+    return getCredentialsScope();
   }
 
   @Override

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/RemotableGoogleCredentials.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/RemotableGoogleCredentials.java
@@ -52,9 +52,7 @@ final class RemotableGoogleCredentials extends GoogleRobotCredentials {
       GoogleRobotCredentialsModule module)
       throws GeneralSecurityException {
     super(
-        credentials.getCredentialsScope() == null
-            ? CredentialsScope.GLOBAL
-            : credentials.getScope(),
+        credentials.getScope() == null ? CredentialsScope.GLOBAL : credentials.getScope(),
         "",
         checkNotNull(credentials).getProjectId(),
         checkNotNull(module));
@@ -105,19 +103,13 @@ final class RemotableGoogleCredentials extends GoogleRobotCredentials {
               + "have a null id when attempted to deserialize. readResolve overwrites these nulls")
   private Object readResolve() throws Exception {
     return new RemotableGoogleCredentials(
-        getCredentialsScope() == null ? CredentialsScope.GLOBAL : getCredentialsScope(),
+        getScope() == null ? CredentialsScope.GLOBAL : getScope(),
         getId() == null ? getProjectId() : getId(),
         getProjectId(),
         getModule(),
         username,
         accessToken,
         expiration);
-  }
-
-  /** {@inheritDoc} */
-  @Override
-  public CredentialsScope getScope() {
-    return getCredentialsScope();
   }
 
   /** {@inheritDoc} */

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/RemotableGoogleCredentials.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/RemotableGoogleCredentials.java
@@ -51,7 +51,13 @@ final class RemotableGoogleCredentials extends GoogleRobotCredentials {
       GoogleOAuth2ScopeRequirement requirement,
       GoogleRobotCredentialsModule module)
       throws GeneralSecurityException {
-    super("", checkNotNull(credentials).getProjectId(), checkNotNull(module));
+    super(
+        credentials.getCredentialsScope() == null
+            ? CredentialsScope.GLOBAL
+            : credentials.getScope(),
+        "",
+        checkNotNull(credentials).getProjectId(),
+        checkNotNull(module));
 
     this.username = credentials.getUsername();
 
@@ -79,13 +85,14 @@ final class RemotableGoogleCredentials extends GoogleRobotCredentials {
    * for migrating old credentials that had no id and relied on the projectId during readResolve().
    */
   private RemotableGoogleCredentials(
+      CredentialsScope scope,
       String id,
       String projectId,
       GoogleRobotCredentialsModule module,
       String username,
       String accessToken,
       long expiration) {
-    super(id, projectId, module);
+    super(scope, id, projectId, module);
     this.username = username;
     this.accessToken = accessToken;
     this.expiration = expiration;
@@ -98,6 +105,7 @@ final class RemotableGoogleCredentials extends GoogleRobotCredentials {
               + "have a null id when attempted to deserialize. readResolve overwrites these nulls")
   private Object readResolve() throws Exception {
     return new RemotableGoogleCredentials(
+        getCredentialsScope() == null ? CredentialsScope.GLOBAL : getCredentialsScope(),
         getId() == null ? getProjectId() : getId(),
         getProjectId(),
         getModule(),
@@ -109,7 +117,7 @@ final class RemotableGoogleCredentials extends GoogleRobotCredentials {
   /** {@inheritDoc} */
   @Override
   public CredentialsScope getScope() {
-    return CredentialsScope.GLOBAL;
+    return getCredentialsScope();
   }
 
   /** {@inheritDoc} */

--- a/src/main/resources/com/google/jenkins/plugins/credentials/oauth/GoogleRobotMetadataCredentials/config.jelly
+++ b/src/main/resources/com/google/jenkins/plugins/credentials/oauth/GoogleRobotMetadataCredentials/config.jelly
@@ -16,6 +16,9 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
          xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+   <f:entry title="${%Scope}" field="scope">
+     <f:select />
+   </f:entry>
    <f:entry title="${%Project Name}" field="projectId">
      <f:textbox default="${descriptor.defaultProject()}" />
    </f:entry>

--- a/src/main/resources/com/google/jenkins/plugins/credentials/oauth/GoogleRobotPrivateKeyCredentials/config.jelly
+++ b/src/main/resources/com/google/jenkins/plugins/credentials/oauth/GoogleRobotPrivateKeyCredentials/config.jelly
@@ -15,6 +15,9 @@
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form">
+  <f:entry title="${%Scope}" field="scope">
+    <f:select />
+  </f:entry>
   <f:entry title="${%Project Name}" field="projectId">
     <f:textbox />
   </f:entry>

--- a/src/test/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotCredentialsTest.java
+++ b/src/test/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotCredentialsTest.java
@@ -50,8 +50,6 @@ public class GoogleRobotCredentialsTest {
   // Allow for testing using JUnit4, instead of JUnit3.
   @Rule public JenkinsRule jenkins = new JenkinsRule();
 
-  private static final CredentialsScope CREDENTIALS_SCOPE = CredentialsScope.GLOBAL;
-
   /** */
   public static class TestRequirement extends TestGoogleOAuth2DomainRequirement {
     public TestRequirement() {
@@ -72,7 +70,7 @@ public class GoogleRobotCredentialsTest {
   @RequiresDomain(value = TestRequirement.class)
   public static class FakeGoogleCredentials extends GoogleRobotCredentials {
     public FakeGoogleCredentials(String projectId, GoogleCredential credential) {
-      super(CREDENTIALS_SCOPE, "", projectId, new GoogleRobotCredentialsModule());
+      super(CredentialsScope.GLOBAL, "", projectId, new GoogleRobotCredentialsModule());
 
       this.credential = credential;
     }
@@ -91,11 +89,6 @@ public class GoogleRobotCredentialsTest {
     @Override
     public String getUsername() {
       return USERNAME;
-    }
-
-    @Override
-    public CredentialsScope getScope() {
-      return getCredentialsScope();
     }
 
     /** */

--- a/src/test/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotCredentialsTest.java
+++ b/src/test/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotCredentialsTest.java
@@ -50,6 +50,8 @@ public class GoogleRobotCredentialsTest {
   // Allow for testing using JUnit4, instead of JUnit3.
   @Rule public JenkinsRule jenkins = new JenkinsRule();
 
+  private static final CredentialsScope CREDENTIALS_SCOPE = CredentialsScope.GLOBAL;
+
   /** */
   public static class TestRequirement extends TestGoogleOAuth2DomainRequirement {
     public TestRequirement() {
@@ -70,7 +72,7 @@ public class GoogleRobotCredentialsTest {
   @RequiresDomain(value = TestRequirement.class)
   public static class FakeGoogleCredentials extends GoogleRobotCredentials {
     public FakeGoogleCredentials(String projectId, GoogleCredential credential) {
-      super("", projectId, new GoogleRobotCredentialsModule());
+      super(CREDENTIALS_SCOPE, "", projectId, new GoogleRobotCredentialsModule());
 
       this.credential = credential;
     }
@@ -93,7 +95,7 @@ public class GoogleRobotCredentialsTest {
 
     @Override
     public CredentialsScope getScope() {
-      return CredentialsScope.GLOBAL;
+      return getCredentialsScope();
     }
 
     /** */

--- a/src/test/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotMetadataCredentialsTest.java
+++ b/src/test/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotMetadataCredentialsTest.java
@@ -318,6 +318,42 @@ public class GoogleRobotMetadataCredentialsTest {
     assertEquals(FormValidation.Kind.ERROR, descriptor.doCheckProjectId("").kind);
   }
 
+  @Test
+  public void testCredentialCreationWithSystemScope() throws Exception {
+    final Module module = new Module();
+
+    // WHEN: creating a credential with SYSTEM scope
+    GoogleRobotMetadataCredentials credentials =
+        new GoogleRobotMetadataCredentials(CredentialsScope.SYSTEM, "", PROJECT_ID, module);
+
+    module.stubRequest(
+        "http://metadata/computeMetadata/v1/instance/" + "service-accounts/default/email",
+        STATUS_CODE_OK,
+        USERNAME);
+
+    // THEN: the resulting credential should have SYSTEM scope
+    assertEquals(CredentialsScope.SYSTEM, credentials.getScope());
+    assertEquals(USERNAME, credentials.getUsername());
+  }
+
+  @Test
+  public void testCredentialCreationWithGlobalScope() throws Exception {
+    final Module module = new Module();
+
+    // WHEN: creating a credential with GLOBAL scope
+    GoogleRobotMetadataCredentials credentials =
+        new GoogleRobotMetadataCredentials(CredentialsScope.GLOBAL, "", PROJECT_ID, module);
+
+    module.stubRequest(
+        "http://metadata/computeMetadata/v1/instance/" + "service-accounts/default/email",
+        STATUS_CODE_OK,
+        USERNAME);
+
+    // THEN: the resulting credential should have GLOBAL scope
+    assertEquals(CredentialsScope.GLOBAL, credentials.getScope());
+    assertEquals(USERNAME, credentials.getUsername());
+  }
+
   private static String METADATA_ENDPOINT =
       OAuth2Utils.getMetadataServerUrl()
           + "/computeMetadata/v1/"

--- a/src/test/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotMetadataCredentialsTest.java
+++ b/src/test/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotMetadataCredentialsTest.java
@@ -59,9 +59,7 @@ public class GoogleRobotMetadataCredentialsTest {
   @Rule public JenkinsRule jenkins = new JenkinsRule();
 
   @Mock private GoogleCredential credential;
-
-  private static final CredentialsScope CREDENTIALS_SCOPE = CredentialsScope.GLOBAL;
-
+  
   /** */
   public static class Module extends GoogleRobotMetadataCredentialsModule {
     @Override
@@ -115,7 +113,7 @@ public class GoogleRobotMetadataCredentialsTest {
     final Module module = new Module();
 
     GoogleRobotMetadataCredentials newCreds =
-        new GoogleRobotMetadataCredentials(CREDENTIALS_SCOPE, "", PROJECT_ID, module);
+        new GoogleRobotMetadataCredentials(CredentialsScope.GLOBAL, "", PROJECT_ID, module);
 
     Credential cred =
         newCreds.getGoogleCredential(new TestGoogleOAuth2DomainRequirement(FAKE_SCOPE));
@@ -142,7 +140,7 @@ public class GoogleRobotMetadataCredentialsTest {
   public void getUsernameTest() throws Exception {
     final Module module = new Module();
     GoogleRobotMetadataCredentials credentials =
-        new GoogleRobotMetadataCredentials(CREDENTIALS_SCOPE, "", PROJECT_ID, module);
+        new GoogleRobotMetadataCredentials(CredentialsScope.GLOBAL, "", PROJECT_ID, module);
 
     module.stubRequest(
         "http://metadata/computeMetadata/v1/instance/" + "service-accounts/default/email",
@@ -157,7 +155,7 @@ public class GoogleRobotMetadataCredentialsTest {
   public void getUsernameWithNotFoundExceptionTest() throws Exception {
     final Module module = new Module();
     GoogleRobotMetadataCredentials credentials =
-        new GoogleRobotMetadataCredentials(CREDENTIALS_SCOPE, "", PROJECT_ID, module);
+        new GoogleRobotMetadataCredentials(CredentialsScope.GLOBAL, "", PROJECT_ID, module);
 
     module.stubRequest(
         "http://metadata/computeMetadata/v1/instance/" + "service-accounts/default/email",
@@ -173,7 +171,7 @@ public class GoogleRobotMetadataCredentialsTest {
   public void getUsernameWithUnknownIOExceptionTest() throws Exception {
     final Module module = new Module();
     GoogleRobotMetadataCredentials credentials =
-        new GoogleRobotMetadataCredentials(CREDENTIALS_SCOPE, "", PROJECT_ID, module);
+        new GoogleRobotMetadataCredentials(CredentialsScope.GLOBAL, "", PROJECT_ID, module);
 
     module.stubRequest(
         "http://metadata/computeMetadata/v1/instance/" + "service-accounts/default/email",
@@ -188,7 +186,7 @@ public class GoogleRobotMetadataCredentialsTest {
   public void defaultProjectTest() throws Exception {
     GoogleRobotMetadataCredentials credentials =
         new GoogleRobotMetadataCredentials(
-            CREDENTIALS_SCOPE, "", "doesn't matter", null /* module */);
+            CredentialsScope.GLOBAL, "", "doesn't matter", null /* module */);
 
     final GoogleRobotMetadataCredentials.Descriptor descriptor = credentials.getDescriptor();
 
@@ -203,7 +201,7 @@ public class GoogleRobotMetadataCredentialsTest {
   public void defaultProjectNotFoundTest() throws Exception {
     GoogleRobotMetadataCredentials credentials =
         new GoogleRobotMetadataCredentials(
-            CREDENTIALS_SCOPE, "", "doesn't matter", null /* module */);
+            CredentialsScope.GLOBAL, "", "doesn't matter", null /* module */);
 
     final GoogleRobotMetadataCredentials.Descriptor descriptor = credentials.getDescriptor();
 
@@ -219,7 +217,7 @@ public class GoogleRobotMetadataCredentialsTest {
   public void defaultProjectUnknownIOExceptionTest() throws Exception {
     GoogleRobotMetadataCredentials credentials =
         new GoogleRobotMetadataCredentials(
-            CREDENTIALS_SCOPE, "", "doesn't matter", null /* module */);
+            CredentialsScope.GLOBAL, "", "doesn't matter", null /* module */);
 
     final GoogleRobotMetadataCredentials.Descriptor descriptor = credentials.getDescriptor();
 
@@ -234,7 +232,7 @@ public class GoogleRobotMetadataCredentialsTest {
   public void defaultScopesTest() throws Exception {
     GoogleRobotMetadataCredentials credentials =
         new GoogleRobotMetadataCredentials(
-            CREDENTIALS_SCOPE, "", "doesn't matter", null /* module */);
+            CredentialsScope.GLOBAL, "", "doesn't matter", null /* module */);
 
     final GoogleRobotMetadataCredentials.Descriptor descriptor = credentials.getDescriptor();
 
@@ -251,7 +249,7 @@ public class GoogleRobotMetadataCredentialsTest {
   public void defaultScopesNotFoundTest() throws Exception {
     GoogleRobotMetadataCredentials credentials =
         new GoogleRobotMetadataCredentials(
-            CREDENTIALS_SCOPE, "", "doesn't matter", null /* module */);
+            CredentialsScope.GLOBAL, "", "doesn't matter", null /* module */);
 
     final GoogleRobotMetadataCredentials.Descriptor descriptor = credentials.getDescriptor();
 
@@ -268,7 +266,7 @@ public class GoogleRobotMetadataCredentialsTest {
   public void defaultScopesUnknownIOExceptionTest() throws Exception {
     GoogleRobotMetadataCredentials credentials =
         new GoogleRobotMetadataCredentials(
-            CREDENTIALS_SCOPE, "", "doesn't matter", null /* module */);
+            CredentialsScope.GLOBAL, "", "doesn't matter", null /* module */);
 
     final GoogleRobotMetadataCredentials.Descriptor descriptor = credentials.getDescriptor();
 
@@ -284,7 +282,7 @@ public class GoogleRobotMetadataCredentialsTest {
   @Test
   public void testGetById() throws Exception {
     GoogleRobotMetadataCredentials credentials =
-        new GoogleRobotMetadataCredentials(CREDENTIALS_SCOPE, "", PROJECT_ID, null /* module */);
+        new GoogleRobotMetadataCredentials(CredentialsScope.GLOBAL, "", PROJECT_ID, null /* module */);
     SystemCredentialsProvider.getInstance().getCredentials().add(credentials);
     Module module = (Module) credentials.getDescriptor().getModule();
 
@@ -300,7 +298,7 @@ public class GoogleRobotMetadataCredentialsTest {
   @Test
   public void testName() throws Exception {
     GoogleRobotMetadataCredentials credentials =
-        new GoogleRobotMetadataCredentials(CREDENTIALS_SCOPE, "", PROJECT_ID, null /* module */);
+        new GoogleRobotMetadataCredentials(CredentialsScope.GLOBAL, "", PROJECT_ID, null /* module */);
     SystemCredentialsProvider.getInstance().getCredentials().add(credentials);
 
     assertEquals(PROJECT_ID, CredentialsNameProvider.name(credentials));

--- a/src/test/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotMetadataCredentialsTest.java
+++ b/src/test/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotMetadataCredentialsTest.java
@@ -60,6 +60,8 @@ public class GoogleRobotMetadataCredentialsTest {
 
   @Mock private GoogleCredential credential;
 
+  private static final CredentialsScope CREDENTIALS_SCOPE = CredentialsScope.GLOBAL;
+
   /** */
   public static class Module extends GoogleRobotMetadataCredentialsModule {
     @Override
@@ -113,7 +115,7 @@ public class GoogleRobotMetadataCredentialsTest {
     final Module module = new Module();
 
     GoogleRobotMetadataCredentials newCreds =
-        new GoogleRobotMetadataCredentials(PROJECT_ID, module);
+        new GoogleRobotMetadataCredentials(CREDENTIALS_SCOPE, "", PROJECT_ID, module);
 
     Credential cred =
         newCreds.getGoogleCredential(new TestGoogleOAuth2DomainRequirement(FAKE_SCOPE));
@@ -140,7 +142,7 @@ public class GoogleRobotMetadataCredentialsTest {
   public void getUsernameTest() throws Exception {
     final Module module = new Module();
     GoogleRobotMetadataCredentials credentials =
-        new GoogleRobotMetadataCredentials(PROJECT_ID, module);
+        new GoogleRobotMetadataCredentials(CREDENTIALS_SCOPE, "", PROJECT_ID, module);
 
     module.stubRequest(
         "http://metadata/computeMetadata/v1/instance/" + "service-accounts/default/email",
@@ -155,7 +157,7 @@ public class GoogleRobotMetadataCredentialsTest {
   public void getUsernameWithNotFoundExceptionTest() throws Exception {
     final Module module = new Module();
     GoogleRobotMetadataCredentials credentials =
-        new GoogleRobotMetadataCredentials(PROJECT_ID, module);
+        new GoogleRobotMetadataCredentials(CREDENTIALS_SCOPE, "", PROJECT_ID, module);
 
     module.stubRequest(
         "http://metadata/computeMetadata/v1/instance/" + "service-accounts/default/email",
@@ -171,7 +173,7 @@ public class GoogleRobotMetadataCredentialsTest {
   public void getUsernameWithUnknownIOExceptionTest() throws Exception {
     final Module module = new Module();
     GoogleRobotMetadataCredentials credentials =
-        new GoogleRobotMetadataCredentials(PROJECT_ID, module);
+        new GoogleRobotMetadataCredentials(CREDENTIALS_SCOPE, "", PROJECT_ID, module);
 
     module.stubRequest(
         "http://metadata/computeMetadata/v1/instance/" + "service-accounts/default/email",
@@ -185,7 +187,8 @@ public class GoogleRobotMetadataCredentialsTest {
   @Test
   public void defaultProjectTest() throws Exception {
     GoogleRobotMetadataCredentials credentials =
-        new GoogleRobotMetadataCredentials("doesn't matter", null /* module */);
+        new GoogleRobotMetadataCredentials(
+            CREDENTIALS_SCOPE, "", "doesn't matter", null /* module */);
 
     final GoogleRobotMetadataCredentials.Descriptor descriptor = credentials.getDescriptor();
 
@@ -199,7 +202,8 @@ public class GoogleRobotMetadataCredentialsTest {
   @Test
   public void defaultProjectNotFoundTest() throws Exception {
     GoogleRobotMetadataCredentials credentials =
-        new GoogleRobotMetadataCredentials("doesn't matter", null /* module */);
+        new GoogleRobotMetadataCredentials(
+            CREDENTIALS_SCOPE, "", "doesn't matter", null /* module */);
 
     final GoogleRobotMetadataCredentials.Descriptor descriptor = credentials.getDescriptor();
 
@@ -214,7 +218,8 @@ public class GoogleRobotMetadataCredentialsTest {
   @Test
   public void defaultProjectUnknownIOExceptionTest() throws Exception {
     GoogleRobotMetadataCredentials credentials =
-        new GoogleRobotMetadataCredentials("doesn't matter", null /* module */);
+        new GoogleRobotMetadataCredentials(
+            CREDENTIALS_SCOPE, "", "doesn't matter", null /* module */);
 
     final GoogleRobotMetadataCredentials.Descriptor descriptor = credentials.getDescriptor();
 
@@ -228,7 +233,8 @@ public class GoogleRobotMetadataCredentialsTest {
   @Test
   public void defaultScopesTest() throws Exception {
     GoogleRobotMetadataCredentials credentials =
-        new GoogleRobotMetadataCredentials("doesn't matter", null /* module */);
+        new GoogleRobotMetadataCredentials(
+            CREDENTIALS_SCOPE, "", "doesn't matter", null /* module */);
 
     final GoogleRobotMetadataCredentials.Descriptor descriptor = credentials.getDescriptor();
 
@@ -244,7 +250,8 @@ public class GoogleRobotMetadataCredentialsTest {
   @Test
   public void defaultScopesNotFoundTest() throws Exception {
     GoogleRobotMetadataCredentials credentials =
-        new GoogleRobotMetadataCredentials("doesn't matter", null /* module */);
+        new GoogleRobotMetadataCredentials(
+            CREDENTIALS_SCOPE, "", "doesn't matter", null /* module */);
 
     final GoogleRobotMetadataCredentials.Descriptor descriptor = credentials.getDescriptor();
 
@@ -260,7 +267,8 @@ public class GoogleRobotMetadataCredentialsTest {
   @Test
   public void defaultScopesUnknownIOExceptionTest() throws Exception {
     GoogleRobotMetadataCredentials credentials =
-        new GoogleRobotMetadataCredentials("doesn't matter", null /* module */);
+        new GoogleRobotMetadataCredentials(
+            CREDENTIALS_SCOPE, "", "doesn't matter", null /* module */);
 
     final GoogleRobotMetadataCredentials.Descriptor descriptor = credentials.getDescriptor();
 
@@ -276,7 +284,7 @@ public class GoogleRobotMetadataCredentialsTest {
   @Test
   public void testGetById() throws Exception {
     GoogleRobotMetadataCredentials credentials =
-        new GoogleRobotMetadataCredentials(PROJECT_ID, null /* module */);
+        new GoogleRobotMetadataCredentials(CREDENTIALS_SCOPE, "", PROJECT_ID, null /* module */);
     SystemCredentialsProvider.getInstance().getCredentials().add(credentials);
     Module module = (Module) credentials.getDescriptor().getModule();
 
@@ -292,7 +300,7 @@ public class GoogleRobotMetadataCredentialsTest {
   @Test
   public void testName() throws Exception {
     GoogleRobotMetadataCredentials credentials =
-        new GoogleRobotMetadataCredentials(PROJECT_ID, null /* module */);
+        new GoogleRobotMetadataCredentials(CREDENTIALS_SCOPE, "", PROJECT_ID, null /* module */);
     SystemCredentialsProvider.getInstance().getCredentials().add(credentials);
 
     assertEquals(PROJECT_ID, CredentialsNameProvider.name(credentials));

--- a/src/test/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotPrivateKeyCredentialsTest.java
+++ b/src/test/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotPrivateKeyCredentialsTest.java
@@ -383,4 +383,42 @@ public class GoogleRobotPrivateKeyCredentialsTest {
     assertEquals(PROJECT_ID, CredentialsNameProvider.name(credentials));
     assertEquals(PROJECT_ID, new GoogleRobotNameProvider().getName(credentials));
   }
+
+  @Test
+  public void testCredentialCreationWithSystemScope() throws Exception {
+    // GIVEN: Setup the mock and configuration
+    when(mockFileItem.getSize()).thenReturn(1L);
+    when(mockFileItem.getName()).thenReturn(jsonKeyPath);
+    when(mockFileItem.getInputStream()).thenReturn(new FileInputStream(jsonKeyPath));
+    when(mockFileItem.get()).thenReturn(FileUtils.readFileToByteArray(new File(jsonKeyPath)));
+    JsonServiceAccountConfig jsonServiceAccountConfig = new JsonServiceAccountConfig();
+    jsonServiceAccountConfig.setJsonKeyFileUpload(mockFileItem);
+
+    // WHEN: creating a credential with SYSTEM scope
+    GoogleRobotPrivateKeyCredentials credentials =
+        new GoogleRobotPrivateKeyCredentials(
+            CredentialsScope.SYSTEM, "", PROJECT_ID, jsonServiceAccountConfig, module);
+
+    // THEN: the resulting credential should have SYSTEM scope
+    assertEquals(CredentialsScope.SYSTEM, credentials.getScope());
+  }
+
+  @Test
+  public void testCredentialCreationWithGlobalScope() throws Exception {
+    // GIVEN: Setup the mock and configuration
+    when(mockFileItem.getSize()).thenReturn(1L);
+    when(mockFileItem.getName()).thenReturn(jsonKeyPath);
+    when(mockFileItem.getInputStream()).thenReturn(new FileInputStream(jsonKeyPath));
+    when(mockFileItem.get()).thenReturn(FileUtils.readFileToByteArray(new File(jsonKeyPath)));
+    JsonServiceAccountConfig jsonServiceAccountConfig = new JsonServiceAccountConfig();
+    jsonServiceAccountConfig.setJsonKeyFileUpload(mockFileItem);
+
+    // WHEN: creating a credential with GLOBAL scope
+    GoogleRobotPrivateKeyCredentials credentials =
+        new GoogleRobotPrivateKeyCredentials(
+            CredentialsScope.GLOBAL, "", PROJECT_ID, jsonServiceAccountConfig, module);
+
+    // THEN: the resulting credential should have GLOBAL scope
+    assertEquals(CredentialsScope.GLOBAL, credentials.getScope());
+  }
 }

--- a/src/test/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotPrivateKeyCredentialsTest.java
+++ b/src/test/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotPrivateKeyCredentialsTest.java
@@ -57,7 +57,6 @@ public class GoogleRobotPrivateKeyCredentialsTest {
   private static final String ACCESS_TOKEN = "ThE.ToKeN";
   private static final String PROJECT_ID = "foo.com:bar-baz";
   private static final String FAKE_SCOPE = "my.fake.scope";
-  private static final CredentialsScope CREDENTIALS_SCOPE = CredentialsScope.GLOBAL;
   private static KeyPair keyPair;
   private static String jsonKeyPath;
   private static String p12KeyPath;
@@ -113,7 +112,7 @@ public class GoogleRobotPrivateKeyCredentialsTest {
     jsonServiceAccountConfig.setJsonKeyFileUpload(mockFileItem);
     GoogleRobotPrivateKeyCredentials credentials =
         new GoogleRobotPrivateKeyCredentials(
-            CREDENTIALS_SCOPE, "", PROJECT_ID, jsonServiceAccountConfig, module);
+            CredentialsScope.GLOBAL, "", PROJECT_ID, jsonServiceAccountConfig, module);
 
     assertEquals(CredentialsScope.GLOBAL, credentials.getScope());
     assertEquals(SERVICE_ACCOUNT_EMAIL_ADDRESS, credentials.getUsername());
@@ -148,7 +147,7 @@ public class GoogleRobotPrivateKeyCredentialsTest {
     P12ServiceAccountConfig keyType = new P12ServiceAccountConfig(SERVICE_ACCOUNT_EMAIL_ADDRESS);
     keyType.setP12KeyFileUpload(mockFileItem);
     GoogleRobotPrivateKeyCredentials credentials =
-        new GoogleRobotPrivateKeyCredentials(CREDENTIALS_SCOPE, "", PROJECT_ID, keyType, module);
+        new GoogleRobotPrivateKeyCredentials(CredentialsScope.GLOBAL, "", PROJECT_ID, keyType, module);
 
     assertEquals(CredentialsScope.GLOBAL, credentials.getScope());
     assertEquals(SERVICE_ACCOUNT_EMAIL_ADDRESS, credentials.getUsername());
@@ -188,7 +187,7 @@ public class GoogleRobotPrivateKeyCredentialsTest {
   @Test
   public void testCreatePrivateKeyCredentialsWithNullKeyType() throws Exception {
     GoogleRobotPrivateKeyCredentials credentials =
-        new GoogleRobotPrivateKeyCredentials(CREDENTIALS_SCOPE, "", PROJECT_ID, null, module);
+        new GoogleRobotPrivateKeyCredentials(CredentialsScope.GLOBAL, "", PROJECT_ID, null, module);
 
     try {
       credentials.getUsername();
@@ -206,7 +205,7 @@ public class GoogleRobotPrivateKeyCredentialsTest {
   @Test
   public void testUpgradeLegacyCredentials() throws Exception {
     GoogleRobotPrivateKeyCredentials legacyCredentials =
-        new GoogleRobotPrivateKeyCredentials(CREDENTIALS_SCOPE, "", PROJECT_ID, null, null);
+        new GoogleRobotPrivateKeyCredentials(CredentialsScope.GLOBAL, "", PROJECT_ID, null, null);
     setPrivateField(legacyCredentials, "secretsFile", legacyJsonKeyPath);
     setPrivateField(legacyCredentials, "p12File", p12KeyPath);
     GoogleRobotPrivateKeyCredentials upgradedCredentials =
@@ -221,7 +220,7 @@ public class GoogleRobotPrivateKeyCredentialsTest {
   @Test
   public void testUpgradeLegacyCredentialsWithoutSecretsFile() throws Exception {
     GoogleRobotPrivateKeyCredentials legacyCredentials =
-        new GoogleRobotPrivateKeyCredentials(CREDENTIALS_SCOPE, "", PROJECT_ID, null, null);
+        new GoogleRobotPrivateKeyCredentials(CredentialsScope.GLOBAL, "", PROJECT_ID, null, null);
     setPrivateField(legacyCredentials, "p12File", p12KeyPath);
     GoogleRobotPrivateKeyCredentials upgradedCredentials =
         (GoogleRobotPrivateKeyCredentials) legacyCredentials.readResolve();
@@ -243,7 +242,7 @@ public class GoogleRobotPrivateKeyCredentialsTest {
     String legacyJsonKeyFileWithMissingWebObject =
         LegacyJsonServiceAccountConfigUtil.createTempLegacyJsonKeyFileWithMissingWebObject();
     GoogleRobotPrivateKeyCredentials legacyCredentials =
-        new GoogleRobotPrivateKeyCredentials(CREDENTIALS_SCOPE, "", PROJECT_ID, null, null);
+        new GoogleRobotPrivateKeyCredentials(CredentialsScope.GLOBAL, "", PROJECT_ID, null, null);
     setPrivateField(legacyCredentials, "secretsFile", legacyJsonKeyFileWithMissingWebObject);
     setPrivateField(legacyCredentials, "p12File", p12KeyPath);
     GoogleRobotPrivateKeyCredentials upgradedCredentials =
@@ -266,7 +265,7 @@ public class GoogleRobotPrivateKeyCredentialsTest {
     String legacyJsonKeyFileWithMissingClientEmail =
         LegacyJsonServiceAccountConfigUtil.createTempLegacyJsonKeyFileWithMissingClientEmail();
     GoogleRobotPrivateKeyCredentials legacyCredentials =
-        new GoogleRobotPrivateKeyCredentials(CREDENTIALS_SCOPE, "", PROJECT_ID, null, null);
+        new GoogleRobotPrivateKeyCredentials(CredentialsScope.GLOBAL, "", PROJECT_ID, null, null);
     setPrivateField(legacyCredentials, "secretsFile", legacyJsonKeyFileWithMissingClientEmail);
     setPrivateField(legacyCredentials, "p12File", p12KeyPath);
     GoogleRobotPrivateKeyCredentials upgradedCredentials =
@@ -289,7 +288,7 @@ public class GoogleRobotPrivateKeyCredentialsTest {
     String invalidLegacyJsonKeyFile =
         LegacyJsonServiceAccountConfigUtil.createTempInvalidLegacyJsonKeyFile();
     GoogleRobotPrivateKeyCredentials legacyCredentials =
-        new GoogleRobotPrivateKeyCredentials(CREDENTIALS_SCOPE, "", PROJECT_ID, null, null);
+        new GoogleRobotPrivateKeyCredentials(CredentialsScope.GLOBAL, "", PROJECT_ID, null, null);
     setPrivateField(legacyCredentials, "secretsFile", invalidLegacyJsonKeyFile);
     setPrivateField(legacyCredentials, "p12File", p12KeyPath);
     GoogleRobotPrivateKeyCredentials upgradedCredentials =
@@ -310,7 +309,7 @@ public class GoogleRobotPrivateKeyCredentialsTest {
   @Test
   public void testUpgradeLegacyCredentialsWithNotExistendSecretsFile() throws Exception {
     GoogleRobotPrivateKeyCredentials legacyCredentials =
-        new GoogleRobotPrivateKeyCredentials(CREDENTIALS_SCOPE, "", PROJECT_ID, null, null);
+        new GoogleRobotPrivateKeyCredentials(CredentialsScope.GLOBAL, "", PROJECT_ID, null, null);
     setPrivateField(legacyCredentials, "secretsFile", "/notExistendSecretsFile");
     setPrivateField(legacyCredentials, "p12File", p12KeyPath);
     GoogleRobotPrivateKeyCredentials upgradedCredentials =
@@ -331,7 +330,7 @@ public class GoogleRobotPrivateKeyCredentialsTest {
   @Test
   public void testUpgradeLegacyCredentialsWithoutP12File() throws Exception {
     GoogleRobotPrivateKeyCredentials legacyCredentials =
-        new GoogleRobotPrivateKeyCredentials(CREDENTIALS_SCOPE, "", PROJECT_ID, null, null);
+        new GoogleRobotPrivateKeyCredentials(CredentialsScope.GLOBAL, "", PROJECT_ID, null, null);
     setPrivateField(legacyCredentials, "secretsFile", legacyJsonKeyPath);
     GoogleRobotPrivateKeyCredentials upgradedCredentials =
         (GoogleRobotPrivateKeyCredentials) legacyCredentials.readResolve();
@@ -354,7 +353,7 @@ public class GoogleRobotPrivateKeyCredentialsTest {
     jsonServiceAccountConfig.setJsonKeyFileUpload(mockFileItem);
     GoogleRobotPrivateKeyCredentials credentials =
         new GoogleRobotPrivateKeyCredentials(
-            CREDENTIALS_SCOPE, "", PROJECT_ID, jsonServiceAccountConfig, null);
+            CredentialsScope.GLOBAL, "", PROJECT_ID, jsonServiceAccountConfig, null);
 
     SystemCredentialsProvider.getInstance().getCredentials().add(credentials);
 
@@ -377,7 +376,7 @@ public class GoogleRobotPrivateKeyCredentialsTest {
   @Test
   public void testName() throws Exception {
     GoogleRobotPrivateKeyCredentials credentials =
-        new GoogleRobotPrivateKeyCredentials(CREDENTIALS_SCOPE, "", PROJECT_ID, null, module);
+        new GoogleRobotPrivateKeyCredentials(CredentialsScope.GLOBAL, "", PROJECT_ID, null, module);
     SystemCredentialsProvider.getInstance().getCredentials().add(credentials);
 
     assertEquals(PROJECT_ID, CredentialsNameProvider.name(credentials));

--- a/src/test/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotPrivateKeyCredentialsTest.java
+++ b/src/test/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotPrivateKeyCredentialsTest.java
@@ -57,6 +57,7 @@ public class GoogleRobotPrivateKeyCredentialsTest {
   private static final String ACCESS_TOKEN = "ThE.ToKeN";
   private static final String PROJECT_ID = "foo.com:bar-baz";
   private static final String FAKE_SCOPE = "my.fake.scope";
+  private static final CredentialsScope CREDENTIALS_SCOPE = CredentialsScope.GLOBAL;
   private static KeyPair keyPair;
   private static String jsonKeyPath;
   private static String p12KeyPath;
@@ -111,7 +112,8 @@ public class GoogleRobotPrivateKeyCredentialsTest {
     JsonServiceAccountConfig jsonServiceAccountConfig = new JsonServiceAccountConfig();
     jsonServiceAccountConfig.setJsonKeyFileUpload(mockFileItem);
     GoogleRobotPrivateKeyCredentials credentials =
-        new GoogleRobotPrivateKeyCredentials(PROJECT_ID, jsonServiceAccountConfig, module);
+        new GoogleRobotPrivateKeyCredentials(
+            CREDENTIALS_SCOPE, "", PROJECT_ID, jsonServiceAccountConfig, module);
 
     assertEquals(CredentialsScope.GLOBAL, credentials.getScope());
     assertEquals(SERVICE_ACCOUNT_EMAIL_ADDRESS, credentials.getUsername());
@@ -146,7 +148,7 @@ public class GoogleRobotPrivateKeyCredentialsTest {
     P12ServiceAccountConfig keyType = new P12ServiceAccountConfig(SERVICE_ACCOUNT_EMAIL_ADDRESS);
     keyType.setP12KeyFileUpload(mockFileItem);
     GoogleRobotPrivateKeyCredentials credentials =
-        new GoogleRobotPrivateKeyCredentials(PROJECT_ID, keyType, module);
+        new GoogleRobotPrivateKeyCredentials(CREDENTIALS_SCOPE, "", PROJECT_ID, keyType, module);
 
     assertEquals(CredentialsScope.GLOBAL, credentials.getScope());
     assertEquals(SERVICE_ACCOUNT_EMAIL_ADDRESS, credentials.getUsername());
@@ -186,7 +188,7 @@ public class GoogleRobotPrivateKeyCredentialsTest {
   @Test
   public void testCreatePrivateKeyCredentialsWithNullKeyType() throws Exception {
     GoogleRobotPrivateKeyCredentials credentials =
-        new GoogleRobotPrivateKeyCredentials(PROJECT_ID, null, module);
+        new GoogleRobotPrivateKeyCredentials(CREDENTIALS_SCOPE, "", PROJECT_ID, null, module);
 
     try {
       credentials.getUsername();
@@ -204,7 +206,7 @@ public class GoogleRobotPrivateKeyCredentialsTest {
   @Test
   public void testUpgradeLegacyCredentials() throws Exception {
     GoogleRobotPrivateKeyCredentials legacyCredentials =
-        new GoogleRobotPrivateKeyCredentials(PROJECT_ID, null, null);
+        new GoogleRobotPrivateKeyCredentials(CREDENTIALS_SCOPE, "", PROJECT_ID, null, null);
     setPrivateField(legacyCredentials, "secretsFile", legacyJsonKeyPath);
     setPrivateField(legacyCredentials, "p12File", p12KeyPath);
     GoogleRobotPrivateKeyCredentials upgradedCredentials =
@@ -219,7 +221,7 @@ public class GoogleRobotPrivateKeyCredentialsTest {
   @Test
   public void testUpgradeLegacyCredentialsWithoutSecretsFile() throws Exception {
     GoogleRobotPrivateKeyCredentials legacyCredentials =
-        new GoogleRobotPrivateKeyCredentials(PROJECT_ID, null, null);
+        new GoogleRobotPrivateKeyCredentials(CREDENTIALS_SCOPE, "", PROJECT_ID, null, null);
     setPrivateField(legacyCredentials, "p12File", p12KeyPath);
     GoogleRobotPrivateKeyCredentials upgradedCredentials =
         (GoogleRobotPrivateKeyCredentials) legacyCredentials.readResolve();
@@ -241,7 +243,7 @@ public class GoogleRobotPrivateKeyCredentialsTest {
     String legacyJsonKeyFileWithMissingWebObject =
         LegacyJsonServiceAccountConfigUtil.createTempLegacyJsonKeyFileWithMissingWebObject();
     GoogleRobotPrivateKeyCredentials legacyCredentials =
-        new GoogleRobotPrivateKeyCredentials(PROJECT_ID, null, null);
+        new GoogleRobotPrivateKeyCredentials(CREDENTIALS_SCOPE, "", PROJECT_ID, null, null);
     setPrivateField(legacyCredentials, "secretsFile", legacyJsonKeyFileWithMissingWebObject);
     setPrivateField(legacyCredentials, "p12File", p12KeyPath);
     GoogleRobotPrivateKeyCredentials upgradedCredentials =
@@ -264,7 +266,7 @@ public class GoogleRobotPrivateKeyCredentialsTest {
     String legacyJsonKeyFileWithMissingClientEmail =
         LegacyJsonServiceAccountConfigUtil.createTempLegacyJsonKeyFileWithMissingClientEmail();
     GoogleRobotPrivateKeyCredentials legacyCredentials =
-        new GoogleRobotPrivateKeyCredentials(PROJECT_ID, null, null);
+        new GoogleRobotPrivateKeyCredentials(CREDENTIALS_SCOPE, "", PROJECT_ID, null, null);
     setPrivateField(legacyCredentials, "secretsFile", legacyJsonKeyFileWithMissingClientEmail);
     setPrivateField(legacyCredentials, "p12File", p12KeyPath);
     GoogleRobotPrivateKeyCredentials upgradedCredentials =
@@ -287,7 +289,7 @@ public class GoogleRobotPrivateKeyCredentialsTest {
     String invalidLegacyJsonKeyFile =
         LegacyJsonServiceAccountConfigUtil.createTempInvalidLegacyJsonKeyFile();
     GoogleRobotPrivateKeyCredentials legacyCredentials =
-        new GoogleRobotPrivateKeyCredentials(PROJECT_ID, null, null);
+        new GoogleRobotPrivateKeyCredentials(CREDENTIALS_SCOPE, "", PROJECT_ID, null, null);
     setPrivateField(legacyCredentials, "secretsFile", invalidLegacyJsonKeyFile);
     setPrivateField(legacyCredentials, "p12File", p12KeyPath);
     GoogleRobotPrivateKeyCredentials upgradedCredentials =
@@ -308,7 +310,7 @@ public class GoogleRobotPrivateKeyCredentialsTest {
   @Test
   public void testUpgradeLegacyCredentialsWithNotExistendSecretsFile() throws Exception {
     GoogleRobotPrivateKeyCredentials legacyCredentials =
-        new GoogleRobotPrivateKeyCredentials(PROJECT_ID, null, null);
+        new GoogleRobotPrivateKeyCredentials(CREDENTIALS_SCOPE, "", PROJECT_ID, null, null);
     setPrivateField(legacyCredentials, "secretsFile", "/notExistendSecretsFile");
     setPrivateField(legacyCredentials, "p12File", p12KeyPath);
     GoogleRobotPrivateKeyCredentials upgradedCredentials =
@@ -329,7 +331,7 @@ public class GoogleRobotPrivateKeyCredentialsTest {
   @Test
   public void testUpgradeLegacyCredentialsWithoutP12File() throws Exception {
     GoogleRobotPrivateKeyCredentials legacyCredentials =
-        new GoogleRobotPrivateKeyCredentials(PROJECT_ID, null, null);
+        new GoogleRobotPrivateKeyCredentials(CREDENTIALS_SCOPE, "", PROJECT_ID, null, null);
     setPrivateField(legacyCredentials, "secretsFile", legacyJsonKeyPath);
     GoogleRobotPrivateKeyCredentials upgradedCredentials =
         (GoogleRobotPrivateKeyCredentials) legacyCredentials.readResolve();
@@ -351,7 +353,8 @@ public class GoogleRobotPrivateKeyCredentialsTest {
     JsonServiceAccountConfig jsonServiceAccountConfig = new JsonServiceAccountConfig();
     jsonServiceAccountConfig.setJsonKeyFileUpload(mockFileItem);
     GoogleRobotPrivateKeyCredentials credentials =
-        new GoogleRobotPrivateKeyCredentials(PROJECT_ID, jsonServiceAccountConfig, null);
+        new GoogleRobotPrivateKeyCredentials(
+            CREDENTIALS_SCOPE, "", PROJECT_ID, jsonServiceAccountConfig, null);
 
     SystemCredentialsProvider.getInstance().getCredentials().add(credentials);
 
@@ -374,7 +377,7 @@ public class GoogleRobotPrivateKeyCredentialsTest {
   @Test
   public void testName() throws Exception {
     GoogleRobotPrivateKeyCredentials credentials =
-        new GoogleRobotPrivateKeyCredentials(PROJECT_ID, null, module);
+        new GoogleRobotPrivateKeyCredentials(CREDENTIALS_SCOPE, "", PROJECT_ID, null, module);
     SystemCredentialsProvider.getInstance().getCredentials().add(credentials);
 
     assertEquals(PROJECT_ID, CredentialsNameProvider.name(credentials));


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

Added scope to the credentials; they were previously created with a global scope
<img width="1164" alt="Screenshot 2023-10-03 at 15 34 37" src="https://github.com/jenkinsci/google-oauth-plugin/assets/35283270/c97c9d72-fb69-4aa5-ae21-e3153deacfa8">
<img width="1176" alt="Screenshot 2023-10-03 at 15 37 33" src="https://github.com/jenkinsci/google-oauth-plugin/assets/35283270/8a12d492-6268-42a3-aa02-3ff88f03b0d1">


### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
