### PR TITLE
Resolve version inconsistency with oauth-credentials

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-2.387.x</artifactId>
-        <version>2465.va_e76ed7b_3061</version>
+        <version>2483.v3b_22f030990a_</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
In #188 a dependency inconsistency was introduced by removing the version of oauth-credentials (at that time `0.646.v02b_66dc03d2e`), see:

https://github.com/jenkinsci/google-oauth-plugin/pull/188/files#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L182

and adding a bom version (`2465.va_e76ed7b_3061`) that contains the previous version (`0.645.ve666a_c332668`) of oauth-credentials.

See bom version added:
https://github.com/jenkinsci/google-oauth-plugin/pull/188/files#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R89

See version of oauth-credentials in bom:
https://github.com/jenkinsci/bom/blob/2465.va_e76ed7b_3061/bom-weekly/pom.xml#L715

Due to this change when installing the google-oauth-plugin to a vanilla Jenkins (2.426.1) the following exception is thrown:

```
2023-11-22 16:11:17.132+0000 [id=160]   WARNING hudson.ExtensionFinder$Sezpoz#_find: Failed to load com.google.jenkins.plugins.credentials.oauth.OAuth2Credentials$DescriptorImpl
java.lang.ClassNotFoundException: com.google.jenkins.plugins.credentials.oauth.OAuth2Credentials$DescriptorImpl
        at hudson.PluginManager$UberClassLoader.lambda$findClass$0(PluginManager.java:2340)
        at java.base/java.util.Optional.orElseThrow(Optional.java:403)
        at hudson.PluginManager$UberClassLoader.findClass(PluginManager.java:2340)
        at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:592)
        at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:525)
        at net.java.sezpoz.IndexItem.element(IndexItem.java:134)
Caused: java.lang.InstantiationException: /var/jenkins_home/plugins/google-oauth-plugin/WEB-INF/lib/google-oauth-plugin.jar might need to be rebuilt
        at net.java.sezpoz.IndexItem.element(IndexItem.java:144)
        at hudson.ExtensionFinder.getClassFromIndex(ExtensionFinder.java:785)
        at hudson.ExtensionFinder$Sezpoz._find(ExtensionFinder.java:745)
        at hudson.ExtensionFinder$Sezpoz$1.find(ExtensionFinder.java:715)
        at hudson.ExtensionFinder$GuiceFinder.refresh(ExtensionFinder.java:342)
        at jenkins.model.Jenkins.refreshExtensions(Jenkins.java:2908)
        at hudson.PluginManager.start(PluginManager.java:990)
        at hudson.model.UpdateCenter$CompleteBatchJob.run(UpdateCenter.java:2367)
        at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539)
        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
        at hudson.remoting.AtmostOneThreadExecutor$Worker.run(AtmostOneThreadExecutor.java:121)
        at java.base/java.lang.Thread.run(Thread.java:840)
2023-11-22 16:11:17.153+0000 [id=160]   WARNING h.ExtensionFinder$GuiceFinder$SezpozModule#configure: Failed to load com.google.jenkins.plugins.credentials.oauth.OAuth2Credentials$DescriptorImpl
java.lang.ClassNotFoundException: com.google.jenkins.plugins.credentials.oauth.OAuth2Credentials$DescriptorImpl
        at hudson.PluginManager$UberClassLoader.lambda$findClass$0(PluginManager.java:2340)
        at java.base/java.util.Optional.orElseThrow(Optional.java:403)
        at hudson.PluginManager$UberClassLoader.findClass(PluginManager.java:2340)
        at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:592)
        at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:525)
        at net.java.sezpoz.IndexItem.element(IndexItem.java:134)
Caused: java.lang.InstantiationException: /var/jenkins_home/plugins/google-oauth-plugin/WEB-INF/lib/google-oauth-plugin.jar might need to be rebuilt
        at net.java.sezpoz.IndexItem.element(IndexItem.java:144)
        at hudson.ExtensionFinder$GuiceFinder$SezpozModule.configure(ExtensionFinder.java:566)
        at com.google.inject.AbstractModule.configure(AbstractModule.java:64)
        at com.google.inject.spi.Elements$RecordingBinder.install(Elements.java:426)
        at com.google.inject.spi.Elements.getElements(Elements.java:113)
        at com.google.inject.internal.InjectorShell$Builder.build(InjectorShell.java:160)
        at com.google.inject.internal.InternalInjectorCreator.build(InternalInjectorCreator.java:107)
        at com.google.inject.internal.InjectorImpl.createChildInjector(InjectorImpl.java:240)
        at hudson.ExtensionFinder$GuiceFinder.refresh(ExtensionFinder.java:347)
        at jenkins.model.Jenkins.refreshExtensions(Jenkins.java:2908)
        at hudson.PluginManager.start(PluginManager.java:990)
        at hudson.model.UpdateCenter$CompleteBatchJob.run(UpdateCenter.java:2367)
        at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539)
        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
        at hudson.remoting.AtmostOneThreadExecutor$Worker.run(AtmostOneThreadExecutor.java:121)
        at java.base/java.lang.Thread.run(Thread.java:840)
2023-11-22 16:11:22.978+0000 [id=186]   INFO    jenkins.InitReactorRunner$1#onAttained: Started initialization
```

This originates back to a java API change in the oauth-credentials-plugin, see https://github.com/jenkinsci/oauth-credentials-plugin/pull/16

With the update of the bom version the proper oauth-credentials plugin is registered as a dependency, see changes between the current and the next bom version:

https://github.com/jenkinsci/bom/compare/2465.va_e76ed7b_3061...2483.v3b_22f030990a_#diff-df30c196b4c4872fdfa9378b991827b2433d220d66f83c0f0a1e868010ee3767R720

The PR aims to resolve issues #200 and #204

### Testing done

Local maven build passed with the updated bom version. 
A locally built hpi file was installed on a vanilla Jenkins (2.426.1), no exceptions were observed.

I'm no expert of dependency chains between different Jenkins plugins, so please take that into consideration, I just followed the clues along the way.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
