### PR TITLE
Adding a validation for the required email field in p12 credentials form

### DIFF
--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/P12ServiceAccountConfig.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/P12ServiceAccountConfig.java
@@ -20,6 +20,7 @@ import com.google.api.client.util.Strings;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
+import hudson.util.FormValidation;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -38,6 +39,8 @@ import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.DoNotUse;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
+import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.verb.POST;
 
 /**
  * Provides authentication mechanism for a service account by setting a service account email
@@ -222,6 +225,16 @@ public class P12ServiceAccountConfig extends ServiceAccountConfig {
   /** Descriptor for P12 service account authentication. */
   @Extension
   public static final class DescriptorImpl extends Descriptor {
+
+    @POST
+    public FormValidation doCheckEmailAddress(
+        @QueryParameter("emailAddress") final String emailAddress) {
+      if (Strings.isNullOrEmpty(emailAddress)) {
+        return FormValidation.error(Messages.P12ServiceAccountConfig_ErrorEmailRequired());
+      }
+      return FormValidation.ok();
+    }
+
     @Override
     public String getDisplayName() {
       return Messages.P12ServiceAccountConfig_DisplayName();

--- a/src/main/resources/com/google/jenkins/plugins/credentials/oauth/Messages.properties
+++ b/src/main/resources/com/google/jenkins/plugins/credentials/oauth/Messages.properties
@@ -17,6 +17,7 @@ GoogleRobotPrivateKeyCredentials.BadCredentials=An error occurred deducing a use
 GoogleRobotPrivateKeyCredentials.ProjectIDError=A project name must be specified
 JsonServiceAccountConfig.DisplayName=JSON key
 P12ServiceAccountConfig.DisplayName=P12 key
+P12ServiceAccountConfig.ErrorEmailRequired=Email address is required
 GoogleRobotMetadataCredentials.DisplayName=Google Service Account from metadata
 GoogleRobotMetadataCredentials.ProjectIDError=A project name must be specified
 GoogleRobotMetadataCredentials.AddProjectIdAuthError=Insufficient privileges to add a project


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
Hello :wave:

While creating a credential using a p12 key, there is no validation of the email field while it should actually be required.

This PR adds a simple form validation adding an error message when no value is specified for the email address.

Here is how the validation looks:

<details><summary>Validation Failure</summary>
<p>

![image](https://github.com/jenkinsci/google-oauth-plugin/assets/311677/cc8ebbf1-c457-4243-96b5-52aae9e7d6af)

</p>
</details> 

<details><summary>Validation Success</summary>
<p>

![image](https://github.com/jenkinsci/google-oauth-plugin/assets/311677/e13e4d32-4d27-46dd-b10d-f0addc203621)

</p>
</details> 

The feature was tested manually using `mvn hpi:run`.


### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
