### PR TITLE
Use Jenkins project-wide formatting configuration

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-buildPlugin(configurations: [
+buildPlugin(useContainerAgent: true, configurations: [
     [ platform: "linux", jdk: "11", jenkins: null ],
     [ platform: "linux", jdk: "17", jenkins: null ],
     [ platform: "linux", jdk: "21", jenkins: null ],

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -36,12 +36,12 @@ by Joshua Bloch in his book Effective Java -->
   <module name="RegexpSingleline">
     <!-- Checks that TODOs are properly formatted.
 
-         The (?&lt;!TODO\(.{0,100}) makes the regex ignore any secondary TODO's on the line
+         The (?&lt;!TODO\(.{0,120}) makes the regex ignore any secondary TODO's on the line
          so that things like //TODO(bob): remove this TODO on 1/1/2020 don't trigger a warning
-         because of the second TODO.  (The {0,100} is because java doesn't recoginize arbitrary
-         length look backs, but we know each java line should be < 100 chars.)
+         because of the second TODO.  (The {0,120} is because java doesn't recoginize arbitrary
+         length look backs, but we know each java line should be < 120 chars.)
     -->
-    <property name="format" value="((//.*)|(\*.*))(?&lt;!TODO\(.{0,100})(TODO[^(])|(TODO\([^)]*$)" />
+    <property name="format" value="((//.*)|(\*.*))(?&lt;!TODO\(.{0,120})(TODO[^(])|(TODO\([^)]*$)" />
     <property name="message" value='All TODOs should be named.  e.g. "TODO(johndoe): Refactor when v2 is released."' />
   </module>
 
@@ -137,7 +137,7 @@ by Joshua Bloch in his book Effective Java -->
 
     <module name="LineLength">
       <!-- Checks if a line is too long. -->
-      <property name="max" value="${com.puppycrawl.tools.checkstyle.checks.sizes.LineLength.max}" default="100"/>
+      <property name="max" value="${com.puppycrawl.tools.checkstyle.checks.sizes.LineLength.max}" default="120"/>
       <property name="severity" value="error"/>
 
       <!--

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,6 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
@@ -29,9 +28,9 @@
   <artifactId>google-oauth-plugin</artifactId>
   <version>${revision}.${changelist}</version>
   <packaging>hpi</packaging>
-
   <name>Google OAuth Credentials plugin</name>
   <url>https://github.com/jenkinsci/google-oauth-plugin/blob/develop/docs/home.md</url>
+
   <licenses>
     <license>
       <name>The Apache V2 License</name>
@@ -60,8 +59,8 @@
   <scm>
     <connection>scm:git:https://github.com/${gitHubRepo}.git</connection>
     <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
-    <url>https://github.com/${gitHubRepo}</url>
     <tag>${scmTag}</tag>
+    <url>https://github.com/${gitHubRepo}</url>
   </scm>
 
   <!-- Bring some sanity to version numbering... -->
@@ -75,19 +74,12 @@
     <oauth2.revision>151</oauth2.revision>
     <google.http.version>1.21.0</google.http.version>
     <spotbugs.effort>Max</spotbugs.effort>
-    <doclint>none</doclint>
     <runSuite>**/GoogleOAuthPluginTestSuite.class</runSuite>
+    <spotless.check.skip>false</spotless.check.skip>
   </properties>
 
   <dependencyManagement>
     <dependencies>
-      <dependency>
-        <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.387.x</artifactId>
-        <version>2483.v3b_22f030990a_</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
       <!-- Ensures version compatibility: https://googleapis.github.io/google-http-java-client/setup.html -->
       <dependency>
         <groupId>com.google.cloud</groupId>
@@ -96,95 +88,17 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <dependency>
+        <groupId>io.jenkins.tools.bom</groupId>
+        <artifactId>bom-2.387.x</artifactId>
+        <version>2483.v3b_22f030990a_</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
     </dependencies>
   </dependencyManagement>
+
   <dependencies>
-    <!--
-      Use API plugins for oft-used transitive dependencies:
-      https://www.jenkins.io/doc/developer/plugin-development/dependencies-and-class-loading/#using-library-wrapper-plugins
-    -->
-    <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>jackson2-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>apache-httpcomponents-client-4-api</artifactId>
-    </dependency>
-    <!-- Apache Commons IO dependency -->
-    <dependency>
-      <groupId>commons-io</groupId>
-      <artifactId>commons-io</artifactId>
-      <!-- from jenkins core -->
-      <scope>provided</scope>
-    </dependency>
-    <!-- org.joda.time -->
-    <dependency>
-      <groupId>joda-time</groupId>
-      <artifactId>joda-time</artifactId>
-      <!-- XStream has deserialization warnings for Jodatime 2.0 or later -->
-      <version>2.12.5</version>
-    </dependency>
-    <!-- Test dependencies -->
-    <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest</artifactId>
-      <version>2.2</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.jenkins</groupId>
-      <artifactId>configuration-as-code</artifactId>
-      <scope>test</scope>
-      <!--Marked as optional so hpi:run does not include it. -->
-      <optional>true</optional>
-    </dependency>
-    <dependency>
-      <groupId>io.jenkins.configuration-as-code</groupId>
-      <artifactId>test-harness</artifactId>
-      <scope>test</scope>
-      <optional>true</optional>
-    </dependency>
-    <!-- OAuth Credentials dependency -->
-    <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>oauth-credentials</artifactId>
-    </dependency>
-    <!-- com.google.http-client -->
-    <dependency>
-      <groupId>com.google.http-client</groupId>
-      <artifactId>google-http-client</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>org.apache.httpcomponents</groupId>
-          <artifactId>httpclient</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.google.code.findbugs</groupId>
-          <artifactId>jsr305</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.google.guava</groupId>
-          <artifactId>guava</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>com.google.http-client</groupId>
-      <artifactId>google-http-client-jackson2</artifactId>
-      <version>1.43.3</version>
-      <exclusions>
-        <exclusion>
-          <groupId>com.google.http-client</groupId>
-          <artifactId>google-http-client</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
     <!-- com.google.api-client -->
     <dependency>
       <groupId>com.google.api-client</groupId>
@@ -192,16 +106,26 @@
       <version>${google.api.version}</version>
       <exclusions>
         <exclusion>
-          <groupId>com.google.http-client</groupId>
-          <artifactId>google-http-client</artifactId>
-        </exclusion>
-        <exclusion>
           <groupId>com.google.code.findbugs</groupId>
           <artifactId>jsr305</artifactId>
         </exclusion>
+        <!-- Provided by core -->
         <exclusion>
           <groupId>com.google.guava</groupId>
           <artifactId>guava</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.google.http-client</groupId>
+          <artifactId>google-http-client</artifactId>
+        </exclusion>
+        <!-- Provided by apache-httpcomponents-client-4-api plugin -->
+        <exclusion>
+          <groupId>org.apache.httpcomponents</groupId>
+          <artifactId>httpclient</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.httpcomponents</groupId>
+          <artifactId>httpcore</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -218,33 +142,129 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <!-- com.google.http-client -->
+    <dependency>
+      <groupId>com.google.http-client</groupId>
+      <artifactId>google-http-client</artifactId>
+      <exclusions>
+        <!-- Provided by jackson2-api plugin -->
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.google.code.findbugs</groupId>
+          <artifactId>jsr305</artifactId>
+        </exclusion>
+        <!-- Provided by core -->
+        <exclusion>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+        </exclusion>
+        <!-- Provided by apache-httpcomponents-client-4-api plugin -->
+        <exclusion>
+          <groupId>org.apache.httpcomponents</groupId>
+          <artifactId>httpclient</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.httpcomponents</groupId>
+          <artifactId>httpcore</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>com.google.http-client</groupId>
+      <artifactId>google-http-client-jackson2</artifactId>
+      <version>1.43.3</version>
+      <exclusions>
+        <!-- Provided by jackson2-api plugin -->
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.google.http-client</groupId>
+          <artifactId>google-http-client</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
     <dependency>
       <groupId>com.google.oauth-client</groupId>
       <artifactId>google-oauth-client</artifactId>
       <version>1.34.1</version>
       <exclusions>
-        <exclusion>
-          <groupId>com.google.http-client</groupId>
-          <artifactId>google-http-client</artifactId>
-        </exclusion>
+        <!-- Provided by core -->
         <exclusion>
           <groupId>com.google.guava</groupId>
           <artifactId>guava</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>com.google.http-client</groupId>
+          <artifactId>google-http-client</artifactId>
+        </exclusion>
       </exclusions>
+    </dependency>
+    <!-- org.joda.time -->
+    <dependency>
+      <groupId>joda-time</groupId>
+      <artifactId>joda-time</artifactId>
+      <!-- XStream has deserialization warnings for Jodatime 2.0 or later -->
+      <version>2.12.5</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>apache-httpcomponents-client-4-api</artifactId>
     </dependency>
     <!-- plugin dependencies -->
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>credentials</artifactId>
     </dependency>
-    <dependency><!-- Required to run P12ServiceAccountConfigTestUtil-dependent tests against newer Jenkins core versions.
+    <!--
+      Use API plugins for oft-used transitive dependencies:
+      https://www.jenkins.io/doc/developer/plugin-development/dependencies-and-class-loading/#using-library-wrapper-plugins
+    -->
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>jackson2-api</artifactId>
+    </dependency>
+    <!-- OAuth Credentials dependency -->
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>oauth-credentials</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.jenkins</groupId>
+      <artifactId>configuration-as-code</artifactId>
+      <scope>test</scope>
+      <!--Marked as optional so hpi:run does not include it. -->
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>io.jenkins.configuration-as-code</groupId>
+      <artifactId>test-harness</artifactId>
+      <scope>test</scope>
+      <optional>true</optional>
+    </dependency>
+    <!-- Test dependencies -->
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <!-- Required to run P12ServiceAccountConfigTestUtil-dependent tests against newer Jenkins core versions.
            Dependency on it does not cause issues in the baseline core even though the plugin is formally incompatible.
            Should it break at some point, the core requirement can be bumped to 2.17.x.
            The BC library can be also shaded if the core requirement needs to be retained.
        -->
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>bouncycastle-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -255,6 +275,7 @@
       <url>https://repo.jenkins-ci.org/public/</url>
     </repository>
   </repositories>
+
   <pluginRepositories>
     <pluginRepository>
       <id>repo.jenkins-ci.org</id>
@@ -286,65 +307,6 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>au.com.acegi</groupId>
-        <artifactId>xml-format-maven-plugin</artifactId>
-        <version>3.2.2</version>
-        <executions>
-          <execution>
-            <id>validate</id>
-            <phase>validate</phase>
-            <goals>
-              <goal>xml-format</goal>
-            </goals>
-          </execution>
-        </executions>
-        <configuration>
-          <includes>pom.xml</includes>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>tidy-maven-plugin</artifactId>
-        <version>1.2.0</version>
-        <executions>
-          <execution>
-            <id>validate</id>
-            <phase>validate</phase>
-            <goals>
-              <goal>pom</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-release-plugin</artifactId>
-        <configuration>
-          <completionGoals>xml-format:xml-format tidy:pom</completionGoals>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>com.coveo</groupId>
-        <artifactId>fmt-maven-plugin</artifactId>
-        <version>2.9</version>
-        <configuration>
-          <sourceDirectory>src/main/java</sourceDirectory>
-          <testSourceDirectory>src/test/java</testSourceDirectory>
-          <verbose>true</verbose>
-          <filesNamePattern>.*\.java</filesNamePattern>
-          <skip>false</skip>
-          <skipSortingImports>false</skipSortingImports>
-          <style>google</style>
-        </configuration>
-        <executions>
-          <execution>
-            <goals>
-              <goal>format</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>cobertura-maven-plugin</artifactId>
         <version>2.7</version>
@@ -354,7 +316,7 @@
               <exclude>com/google/jenkins/plugins/**/Messages.class</exclude>
             </excludes>
           </instrumentation>
-          <check/>
+          <check />
           <formats>
             <format>html</format>
             <format>xml</format>
@@ -373,18 +335,4 @@
       </plugin>
     </plugins>
   </build>
-
-  <reporting>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.4.1</version>
-        <configuration>
-          <show>public</show>
-          <source>8</source>
-        </configuration>
-      </plugin>
-    </plugins>
-  </reporting>
 </project>

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleOAuth2Credentials.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleOAuth2Credentials.java
@@ -24,15 +24,13 @@ import java.security.GeneralSecurityException;
  * <p>Implementations surface an API for obtaining the Google-standard {@link Credential} object for
  * interacting with OAuth2 APIs.
  */
-public interface GoogleOAuth2Credentials
-    extends StandardUsernameOAuth2Credentials<GoogleOAuth2ScopeRequirement> {
-  /**
-   * Fetches a Credential for the set of OAuth 2.0 scopes required.
-   *
-   * @param requirement The set of required OAuth 2.0 scopes
-   * @return The Credential authorizing usage of the API scopes
-   * @throws GeneralSecurityException when the authentication fails
-   */
-  Credential getGoogleCredential(GoogleOAuth2ScopeRequirement requirement)
-      throws GeneralSecurityException;
+public interface GoogleOAuth2Credentials extends StandardUsernameOAuth2Credentials<GoogleOAuth2ScopeRequirement> {
+    /**
+     * Fetches a Credential for the set of OAuth 2.0 scopes required.
+     *
+     * @param requirement The set of required OAuth 2.0 scopes
+     * @return The Credential authorizing usage of the API scopes
+     * @throws GeneralSecurityException when the authentication fails
+     */
+    Credential getGoogleCredential(GoogleOAuth2ScopeRequirement requirement) throws GeneralSecurityException;
 }

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleOAuth2ScopeSpecification.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleOAuth2ScopeSpecification.java
@@ -23,27 +23,26 @@ import org.kohsuke.stapler.DataBoundConstructor;
  * A Google-specific implementation of the {@link OAuth2ScopeSpecification} that limits its
  * application to Google-specific {@link OAuth2ScopeRequirement}
  */
-public class GoogleOAuth2ScopeSpecification
-    extends OAuth2ScopeSpecification<GoogleOAuth2ScopeRequirement> {
-  @DataBoundConstructor
-  public GoogleOAuth2ScopeSpecification(Collection<String> specifiedScopes) {
-    super(specifiedScopes);
-  }
-
-  /**
-   * Denoted this class is a {@code DomainSpecification} plugin, in particular for {@link
-   * OAuth2ScopeSpecification}
-   */
-  @Extension
-  public static class DescriptorImpl extends OAuth2ScopeSpecification.Descriptor {
-    public DescriptorImpl() {
-      super(GoogleOAuth2ScopeRequirement.class);
+public class GoogleOAuth2ScopeSpecification extends OAuth2ScopeSpecification<GoogleOAuth2ScopeRequirement> {
+    @DataBoundConstructor
+    public GoogleOAuth2ScopeSpecification(Collection<String> specifiedScopes) {
+        super(specifiedScopes);
     }
 
-    /** {@inheritDoc} */
-    @Override
-    public String getDisplayName() {
-      return Messages.GoogleOAuth2ScopeSpecification_DisplayName();
+    /**
+     * Denoted this class is a {@code DomainSpecification} plugin, in particular for {@link
+     * OAuth2ScopeSpecification}
+     */
+    @Extension
+    public static class DescriptorImpl extends OAuth2ScopeSpecification.Descriptor {
+        public DescriptorImpl() {
+            super(GoogleOAuth2ScopeRequirement.class);
+        }
+
+        /** {@inheritDoc} */
+        @Override
+        public String getDisplayName() {
+            return Messages.GoogleOAuth2ScopeSpecification_DisplayName();
+        }
     }
-  }
 }

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotCredentials.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotCredentials.java
@@ -43,225 +43,215 @@ import org.kohsuke.stapler.QueryParameter;
  *
  * @author Matt Moore
  */
-public abstract class GoogleRobotCredentials extends BaseStandardCredentials
-    implements GoogleOAuth2Credentials {
+public abstract class GoogleRobotCredentials extends BaseStandardCredentials implements GoogleOAuth2Credentials {
 
-  /**
-   * Base constructor for populating the name and id for Google credentials.
-   *
-   * @param projectId The project id with which this credential is associated.
-   * @param module The module to use for instantiating the dependencies of credentials.
-   */
-  @Deprecated
-  protected GoogleRobotCredentials(String projectId, GoogleRobotCredentialsModule module) {
-    this(CredentialsScope.GLOBAL, "", projectId, module);
-  }
-
-  /**
-   * Base constructor for populating the scope, name, id, and project id for Google credentials.
-   * Leave the id empty to generate a new one, populate the id when updating an existing credential
-   * or migrating from using the project id as the credential id. Use the scope to define the extent
-   * to which these credentials are available within Jenkins (i.e., GLOBAL or SYSTEM).
-   *
-   * @param scope The scope of the credentials, determining where they can be used in Jenkins. Can
-   *     be either GLOBAL or SYSTEM.
-   * @param id The credential ID to assign.
-   * @param projectId The project id with which this credential is associated.
-   * @param description The credential description
-   * @param module The module to use for instantiating the dependencies of credentials.
-   */
-  protected GoogleRobotCredentials(
-      @CheckForNull CredentialsScope scope,
-      String id,
-      String projectId,
-      String description,
-      GoogleRobotCredentialsModule module) {
-    super(scope, id == null ? "" : id, description);
-    this.projectId = checkNotNull(projectId);
-
-    if (module != null) {
-      this.module = module;
-    } else {
-      this.module = getDescriptor().getModule();
+    /**
+     * Base constructor for populating the name and id for Google credentials.
+     *
+     * @param projectId The project id with which this credential is associated.
+     * @param module The module to use for instantiating the dependencies of credentials.
+     */
+    @Deprecated
+    protected GoogleRobotCredentials(String projectId, GoogleRobotCredentialsModule module) {
+        this(CredentialsScope.GLOBAL, "", projectId, module);
     }
-  }
 
-  @Deprecated
-  protected GoogleRobotCredentials(
-      @CheckForNull CredentialsScope scope,
-      String id,
-      String projectId,
-      GoogleRobotCredentialsModule module) {
-    this(scope, id, projectId, null, module);
-  }
+    /**
+     * Base constructor for populating the scope, name, id, and project id for Google credentials.
+     * Leave the id empty to generate a new one, populate the id when updating an existing credential
+     * or migrating from using the project id as the credential id. Use the scope to define the extent
+     * to which these credentials are available within Jenkins (i.e., GLOBAL or SYSTEM).
+     *
+     * @param scope The scope of the credentials, determining where they can be used in Jenkins. Can
+     *     be either GLOBAL or SYSTEM.
+     * @param id The credential ID to assign.
+     * @param projectId The project id with which this credential is associated.
+     * @param description The credential description
+     * @param module The module to use for instantiating the dependencies of credentials.
+     */
+    protected GoogleRobotCredentials(
+            @CheckForNull CredentialsScope scope,
+            String id,
+            String projectId,
+            String description,
+            GoogleRobotCredentialsModule module) {
+        super(scope, id == null ? "" : id, description);
+        this.projectId = checkNotNull(projectId);
 
-  /** Fetch the module used for instantiating the dependencies of credentials */
-  public GoogleRobotCredentialsModule getModule() {
-    return module;
-  }
-
-  private final GoogleRobotCredentialsModule module;
-
-  /** {@inheritDoc} */
-  @Override
-  public AbstractGoogleRobotCredentialsDescriptor getDescriptor() {
-    return (AbstractGoogleRobotCredentialsDescriptor) Jenkins.get().getDescriptorOrDie(getClass());
-  }
-
-  /** {@inheritDoc} */
-  @Override
-  public Secret getAccessToken(GoogleOAuth2ScopeRequirement requirement) {
-    try {
-      Credential credential = getGoogleCredential(requirement);
-
-      Long rawExpiration = credential.getExpiresInSeconds();
-      if ((rawExpiration == null) || (rawExpiration < MINIMUM_DURATION_SECONDS)) {
-        // Access token expired or is near expiration.
-        if (!credential.refreshToken()) {
-          return null;
+        if (module != null) {
+            this.module = module;
+        } else {
+            this.module = getDescriptor().getModule();
         }
-      }
-
-      return Secret.fromString(credential.getAccessToken());
-    } catch (IOException | GeneralSecurityException e) {
-      return null;
-    }
-  }
-
-  /* 3 minutes*/
-  /** The minimum duration to allow for an access token before attempting to refresh it. */
-  private static final Long MINIMUM_DURATION_SECONDS = 180L;
-
-  /**
-   * A trivial tuple for wrapping the list box of matched credentials with the requirements that
-   * were used to filter them.
-   */
-  public static class CredentialsListBoxModel extends ListBoxModel {
-    public CredentialsListBoxModel(GoogleOAuth2ScopeRequirement requirement) {
-      this.requirement = requirement;
     }
 
-    /** Retrieve the set of scopes for our requirement. */
-    public Iterable<String> getScopes() {
-      return requirement.getScopes();
+    @Deprecated
+    protected GoogleRobotCredentials(
+            @CheckForNull CredentialsScope scope, String id, String projectId, GoogleRobotCredentialsModule module) {
+        this(scope, id, projectId, null, module);
     }
 
-    private final GoogleOAuth2ScopeRequirement requirement;
-
-    @Override
-    public boolean equals(Object o) {
-      if (this == o) {
-        return true;
-      }
-      if (o == null || getClass() != o.getClass()) {
-        return false;
-      }
-      if (!super.equals(o)) {
-        return false;
-      }
-      CredentialsListBoxModel options = (CredentialsListBoxModel) o;
-      return Objects.equals(requirement, options.requirement);
-    }
-
-    @Override
-    public int hashCode() {
-      return Objects.hash(super.hashCode(), requirement);
-    }
-  }
-
-  /** The descriptor for Google robot account credential extensions */
-  protected abstract static class AbstractGoogleRobotCredentialsDescriptor
-      extends BaseStandardCredentialsDescriptor {
-    protected AbstractGoogleRobotCredentialsDescriptor(
-        Class<? extends GoogleRobotCredentials> clazz, GoogleRobotCredentialsModule module) {
-      super(clazz);
-      this.module = checkNotNull(module);
-    }
-
-    protected AbstractGoogleRobotCredentialsDescriptor(
-        Class<? extends GoogleRobotCredentials> clazz) {
-      this(clazz, new GoogleRobotCredentialsModule());
-    }
-
-    /** The module to use for instantiating depended upon resources */
+    /** Fetch the module used for instantiating the dependencies of credentials */
     public GoogleRobotCredentialsModule getModule() {
-      return module;
+        return module;
     }
 
     private final GoogleRobotCredentialsModule module;
 
-    /** Validate project-id entries */
-    public FormValidation doCheckProjectId(@QueryParameter String projectId) {
-      if (!Strings.isNullOrEmpty(projectId)) {
-        return FormValidation.ok();
-      } else {
-        return FormValidation.error(Messages.GoogleRobotMetadataCredentials_ProjectIDError());
-      }
+    /** {@inheritDoc} */
+    @Override
+    public AbstractGoogleRobotCredentialsDescriptor getDescriptor() {
+        return (AbstractGoogleRobotCredentialsDescriptor) Jenkins.get().getDescriptorOrDie(getClass());
     }
 
-    /** For {@link java.io.Serializable} */
-    private static final long serialVersionUID = 1L;
-  }
+    /** {@inheritDoc} */
+    @Override
+    public Secret getAccessToken(GoogleOAuth2ScopeRequirement requirement) {
+        try {
+            Credential credential = getGoogleCredential(requirement);
 
-  /**
-   * Helper utility for populating a jelly list box with matching {@link GoogleRobotCredentials} to
-   * avoid listing credentials that avoids surfacing those with insufficient permissions.
-   *
-   * <p>Modeled after: http://developer-blog.cloudbees.com/2012/10/using-ssh-from-jenkins.html
-   *
-   * @param clazz The class annotated with @RequiresDomain indicating its scope requirements.
-   * @return a list box populated solely with credentials compatible for the extension being
-   *     configured.
-   */
-  public static CredentialsListBoxModel getCredentialsListBox(Class<?> clazz) {
-    GoogleOAuth2ScopeRequirement requirement =
-        DomainRequirementProvider.of(clazz, GoogleOAuth2ScopeRequirement.class);
+            Long rawExpiration = credential.getExpiresInSeconds();
+            if ((rawExpiration == null) || (rawExpiration < MINIMUM_DURATION_SECONDS)) {
+                // Access token expired or is near expiration.
+                if (!credential.refreshToken()) {
+                    return null;
+                }
+            }
 
-    if (requirement == null) {
-      throw new IllegalArgumentException(
-          Messages.GoogleRobotCredentials_NoAnnotation(clazz.getSimpleName()));
+            return Secret.fromString(credential.getAccessToken());
+        } catch (IOException | GeneralSecurityException e) {
+            return null;
+        }
     }
 
-    CredentialsListBoxModel listBox = new CredentialsListBoxModel(requirement);
-    Iterable<GoogleRobotCredentials> allGoogleCredentials =
-        CredentialsProvider.lookupCredentials(
-            GoogleRobotCredentials.class, Jenkins.get(), ACL.SYSTEM, ImmutableList.of(requirement));
+    /* 3 minutes*/
+    /** The minimum duration to allow for an access token before attempting to refresh it. */
+    private static final Long MINIMUM_DURATION_SECONDS = 180L;
 
-    for (GoogleRobotCredentials credentials : allGoogleCredentials) {
-      String name = CredentialsNameProvider.name(credentials);
-      listBox.add(name, credentials.getId());
+    /**
+     * A trivial tuple for wrapping the list box of matched credentials with the requirements that
+     * were used to filter them.
+     */
+    public static class CredentialsListBoxModel extends ListBoxModel {
+        public CredentialsListBoxModel(GoogleOAuth2ScopeRequirement requirement) {
+            this.requirement = requirement;
+        }
+
+        /** Retrieve the set of scopes for our requirement. */
+        public Iterable<String> getScopes() {
+            return requirement.getScopes();
+        }
+
+        private final GoogleOAuth2ScopeRequirement requirement;
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            if (!super.equals(o)) {
+                return false;
+            }
+            CredentialsListBoxModel options = (CredentialsListBoxModel) o;
+            return Objects.equals(requirement, options.requirement);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(super.hashCode(), requirement);
+        }
     }
-    return listBox;
-  }
 
-  /** Retrieves the {@link GoogleRobotCredentials} identified by {@code id}. */
-  public static GoogleRobotCredentials getById(String id) {
-    Iterable<GoogleRobotCredentials> allGoogleCredentials =
-        CredentialsProvider.lookupCredentials(
-            GoogleRobotCredentials.class, Jenkins.get(), ACL.SYSTEM, Collections.emptyList());
+    /** The descriptor for Google robot account credential extensions */
+    protected abstract static class AbstractGoogleRobotCredentialsDescriptor extends BaseStandardCredentialsDescriptor {
+        protected AbstractGoogleRobotCredentialsDescriptor(
+                Class<? extends GoogleRobotCredentials> clazz, GoogleRobotCredentialsModule module) {
+            super(clazz);
+            this.module = checkNotNull(module);
+        }
 
-    for (GoogleRobotCredentials credentials : allGoogleCredentials) {
-      if (credentials.getId().equals(id)) {
-        return credentials;
-      }
+        protected AbstractGoogleRobotCredentialsDescriptor(Class<? extends GoogleRobotCredentials> clazz) {
+            this(clazz, new GoogleRobotCredentialsModule());
+        }
+
+        /** The module to use for instantiating depended upon resources */
+        public GoogleRobotCredentialsModule getModule() {
+            return module;
+        }
+
+        private final GoogleRobotCredentialsModule module;
+
+        /** Validate project-id entries */
+        public FormValidation doCheckProjectId(@QueryParameter String projectId) {
+            if (!Strings.isNullOrEmpty(projectId)) {
+                return FormValidation.ok();
+            } else {
+                return FormValidation.error(Messages.GoogleRobotMetadataCredentials_ProjectIDError());
+            }
+        }
+
+        /** For {@link java.io.Serializable} */
+        private static final long serialVersionUID = 1L;
     }
-    return null;
-  }
 
-  /** Retrieve a version of the credential that can be used on a remote machine. */
-  public GoogleRobotCredentials forRemote(GoogleOAuth2ScopeRequirement requirement)
-      throws GeneralSecurityException {
-    if (this instanceof RemotableGoogleCredentials) {
-      return this;
-    } else {
-      return new RemotableGoogleCredentials(this, requirement, getModule());
+    /**
+     * Helper utility for populating a jelly list box with matching {@link GoogleRobotCredentials} to
+     * avoid listing credentials that avoids surfacing those with insufficient permissions.
+     *
+     * <p>Modeled after: http://developer-blog.cloudbees.com/2012/10/using-ssh-from-jenkins.html
+     *
+     * @param clazz The class annotated with @RequiresDomain indicating its scope requirements.
+     * @return a list box populated solely with credentials compatible for the extension being
+     *     configured.
+     */
+    public static CredentialsListBoxModel getCredentialsListBox(Class<?> clazz) {
+        GoogleOAuth2ScopeRequirement requirement =
+                DomainRequirementProvider.of(clazz, GoogleOAuth2ScopeRequirement.class);
+
+        if (requirement == null) {
+            throw new IllegalArgumentException(Messages.GoogleRobotCredentials_NoAnnotation(clazz.getSimpleName()));
+        }
+
+        CredentialsListBoxModel listBox = new CredentialsListBoxModel(requirement);
+        Iterable<GoogleRobotCredentials> allGoogleCredentials = CredentialsProvider.lookupCredentials(
+                GoogleRobotCredentials.class, Jenkins.get(), ACL.SYSTEM, ImmutableList.of(requirement));
+
+        for (GoogleRobotCredentials credentials : allGoogleCredentials) {
+            String name = CredentialsNameProvider.name(credentials);
+            listBox.add(name, credentials.getId());
+        }
+        return listBox;
     }
-  }
 
-  /** Retrieve the project id for this credential */
-  public String getProjectId() {
-    return projectId;
-  }
+    /** Retrieves the {@link GoogleRobotCredentials} identified by {@code id}. */
+    public static GoogleRobotCredentials getById(String id) {
+        Iterable<GoogleRobotCredentials> allGoogleCredentials = CredentialsProvider.lookupCredentials(
+                GoogleRobotCredentials.class, Jenkins.get(), ACL.SYSTEM, Collections.emptyList());
 
-  private final String projectId;
+        for (GoogleRobotCredentials credentials : allGoogleCredentials) {
+            if (credentials.getId().equals(id)) {
+                return credentials;
+            }
+        }
+        return null;
+    }
+
+    /** Retrieve a version of the credential that can be used on a remote machine. */
+    public GoogleRobotCredentials forRemote(GoogleOAuth2ScopeRequirement requirement) throws GeneralSecurityException {
+        if (this instanceof RemotableGoogleCredentials) {
+            return this;
+        } else {
+            return new RemotableGoogleCredentials(this, requirement, getModule());
+        }
+    }
+
+    /** Retrieve the project id for this credential */
+    public String getProjectId() {
+        return projectId;
+    }
+
+    private final String projectId;
 }

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotCredentialsModule.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotCredentialsModule.java
@@ -26,16 +26,16 @@ import java.io.Serializable;
  * GoogleRobotCredentials}.
  */
 public class GoogleRobotCredentialsModule implements Serializable {
-  /** The HttpTransport to use for credential related requests. */
-  public HttpTransport getHttpTransport() {
-    return new NetHttpTransport();
-  }
+    /** The HttpTransport to use for credential related requests. */
+    public HttpTransport getHttpTransport() {
+        return new NetHttpTransport();
+    }
 
-  /** The HttpTransport to use for credential related requests. */
-  public JsonFactory getJsonFactory() {
-    return new JacksonFactory();
-  }
+    /** The HttpTransport to use for credential related requests. */
+    public JsonFactory getJsonFactory() {
+        return new JacksonFactory();
+    }
 
-  /** For {@link Serializable} */
-  private static final long serialVersionUID = 1L;
+    /** For {@link Serializable} */
+    private static final long serialVersionUID = 1L;
 }

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotMetadataCredentials.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotMetadataCredentials.java
@@ -47,212 +47,211 @@ import org.kohsuke.stapler.DataBoundConstructor;
  */
 @NameWith(value = GoogleRobotNameProvider.class, priority = 50)
 public final class GoogleRobotMetadataCredentials extends GoogleRobotCredentials
-    implements DomainRestrictedCredentials {
+        implements DomainRestrictedCredentials {
 
-  /**
-   * Construct a set of service account credentials.
-   *
-   * @param projectId The Pantheon project id associated with this service account
-   * @param module The module for instantiating dependent objects, or null.
-   */
-  @Deprecated
-  public GoogleRobotMetadataCredentials(
-      String projectId, @Nullable GoogleRobotMetadataCredentialsModule module) throws Exception {
-    super(CredentialsScope.GLOBAL, "", projectId, module);
-  }
-
-  @Deprecated
-  public GoogleRobotMetadataCredentials(
-      @CheckForNull CredentialsScope scope,
-      String id,
-      String projectId,
-      @Nullable GoogleRobotMetadataCredentialsModule module)
-      throws Exception {
-    super(scope, id, projectId, module);
-  }
-
-  /**
-   * Construct a set of service account credentials with a specific id. It helps for updating
-   * credentials, as well as for migrating old credentials that had no id and relied on the project
-   * id.
-   *
-   * @param scope The scope of the credentials, determining where they can be used in Jenkins. Can
-   *     be either GLOBAL or SYSTEM.
-   * @param id the id to assign
-   * @param projectId The Pantheon project id associated with this service account
-   * @param description The credential description
-   * @param module The module for instantiating dependent objects, or null.
-   */
-  @DataBoundConstructor
-  public GoogleRobotMetadataCredentials(
-      @CheckForNull CredentialsScope scope,
-      String id,
-      String projectId,
-      String description,
-      @Nullable GoogleRobotMetadataCredentialsModule module)
-      throws Exception {
-    super(scope, id, projectId, description, module);
-  }
-
-  @SuppressFBWarnings(
-      value = "RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE",
-      justification =
-          "For migration purposes: older credentials might not have had separate id or "
-              + "scope fields. These fields might be null when deserializing. The readResolve "
-              + "method sets defaults for null id and scope. Id defaults to getProjectId() and "
-              + "scope defaults to CredentialsScope.GLOBAL if null.")
-  private Object readResolve() throws Exception {
-    return new GoogleRobotMetadataCredentials(
-        getScope() == null ? CredentialsScope.GLOBAL : getScope(),
-        getId() == null ? getProjectId() : getId(),
-        getProjectId(),
-        getDescription(),
-        getModule());
-  }
-
-  /** {@inheritDoc} */
-  @Override
-  public GoogleRobotMetadataCredentialsModule getModule() {
-    // down-cast to our required type
-    return (GoogleRobotMetadataCredentialsModule) super.getModule();
-  }
-
-  /** {@inheritDoc} */
-  @Override
-  public synchronized boolean matches(List<DomainRequirement> requirements) {
-    if (metadataScopes == null) {
-      metadataScopes =
-          new Domain(
-              "metadata",
-              "",
-              ImmutableList.of(
-                  new GoogleOAuth2ScopeSpecification(getDescriptor().defaultScopes())));
-    }
-    return metadataScopes.test(requirements);
-  }
-
-  @Nullable private transient Domain metadataScopes;
-
-  /** {@inheritDoc} */
-  @Override
-  public String getUsername() {
-    try {
-      return getModule().getMetadataReader().readMetadata(IDENTITY_PATH);
-    } catch (ExecutorException | IOException e) {
-      throw new IllegalStateException(
-          Messages.GoogleRobotMetadataCredentials_DefaultIdentityError(), e);
-    }
-  }
-
-  /**
-   * The endpoint of the {@code METADATA_SERVER} for resolving the identity (email) of the service
-   * account.
-   */
-  private static final String IDENTITY_PATH = "/instance/service-accounts/default/email";
-
-  /** {@inheritDoc} */
-  @Override
-  public ComputeCredential getGoogleCredential(GoogleOAuth2ScopeRequirement requirement)
-      throws GeneralSecurityException {
-    // Ideally GCE would allow us to down-scope the metadata credentials we are
-    // providing a given library.
-    return new ComputeCredential(getModule().getHttpTransport(), getModule().getJsonFactory());
-  }
-
-  /** {@inheritDoc} */
-  @Override
-  public Descriptor getDescriptor() {
-    return (Descriptor) super.getDescriptor();
-  }
-
-  /** Descriptor for our unlimited service account extension. */
-  public static class Descriptor extends AbstractGoogleRobotCredentialsDescriptor {
     /**
-     * This factory method determines whether the host machine has an associated metadata server,
-     * and if so registers the metadata-based robot credential.
+     * Construct a set of service account credentials.
+     *
+     * @param projectId The Pantheon project id associated with this service account
+     * @param module The module for instantiating dependent objects, or null.
      */
-    @Extension
-    @Nullable
-    public static Descriptor metadataDescriptor() throws IOException {
-      if (disableForTesting) {
-        // For unit testing, we want to provide custom startup logic, in
-        // particular, we want to unconditionally instantiate it and do so with
-        // a module where we can mock out the MetadataReader's HttpTransport
-        // layer.
-        return null;
-      }
-
-      GoogleRobotMetadataCredentialsModule defaultModule =
-          new GoogleRobotMetadataCredentialsModule();
-      if (defaultModule.getMetadataReader().hasMetadata()) {
-        // Otherwise only instantiate the metadata credential if we are on a
-        // machine with metadata.
-        return new Descriptor(defaultModule);
-      }
-      return null;
+    @Deprecated
+    public GoogleRobotMetadataCredentials(String projectId, @Nullable GoogleRobotMetadataCredentialsModule module)
+            throws Exception {
+        super(CredentialsScope.GLOBAL, "", projectId, module);
     }
 
-    /** Used by unit testing to take control of how the descriptor is instantiated by Jenkins. */
-    @VisibleForTesting static boolean disableForTesting = false;
-
-    @VisibleForTesting
-    Descriptor(GoogleRobotMetadataCredentialsModule module) {
-      super(GoogleRobotMetadataCredentials.class, module);
+    @Deprecated
+    public GoogleRobotMetadataCredentials(
+            @CheckForNull CredentialsScope scope,
+            String id,
+            String projectId,
+            @Nullable GoogleRobotMetadataCredentialsModule module)
+            throws Exception {
+        super(scope, id, projectId, module);
     }
 
-    /** {@inheritDoc} */
-    @Override
-    public String getDisplayName() {
-      return Messages.GoogleRobotMetadataCredentials_DisplayName();
+    /**
+     * Construct a set of service account credentials with a specific id. It helps for updating
+     * credentials, as well as for migrating old credentials that had no id and relied on the project
+     * id.
+     *
+     * @param scope The scope of the credentials, determining where they can be used in Jenkins. Can
+     *     be either GLOBAL or SYSTEM.
+     * @param id the id to assign
+     * @param projectId The Pantheon project id associated with this service account
+     * @param description The credential description
+     * @param module The module for instantiating dependent objects, or null.
+     */
+    @DataBoundConstructor
+    public GoogleRobotMetadataCredentials(
+            @CheckForNull CredentialsScope scope,
+            String id,
+            String projectId,
+            String description,
+            @Nullable GoogleRobotMetadataCredentialsModule module)
+            throws Exception {
+        super(scope, id, projectId, description, module);
+    }
+
+    @SuppressFBWarnings(
+            value = "RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE",
+            justification = "For migration purposes: older credentials might not have had separate id or "
+                    + "scope fields. These fields might be null when deserializing. The readResolve "
+                    + "method sets defaults for null id and scope. Id defaults to getProjectId() and "
+                    + "scope defaults to CredentialsScope.GLOBAL if null.")
+    private Object readResolve() throws Exception {
+        return new GoogleRobotMetadataCredentials(
+                getScope() == null ? CredentialsScope.GLOBAL : getScope(),
+                getId() == null ? getProjectId() : getId(),
+                getProjectId(),
+                getDescription(),
+                getModule());
     }
 
     /** {@inheritDoc} */
     @Override
     public GoogleRobotMetadataCredentialsModule getModule() {
-      return (GoogleRobotMetadataCredentialsModule) super.getModule();
+        // down-cast to our required type
+        return (GoogleRobotMetadataCredentialsModule) super.getModule();
     }
 
-    /**
-     * When we are running on GCE, we should be able to pre-populate the {@code projectId} field
-     * with the "right" project id.
-     *
-     * @return the project associated with this GCE instance, or null.
-     */
+    /** {@inheritDoc} */
+    @Override
+    public synchronized boolean matches(List<DomainRequirement> requirements) {
+        if (metadataScopes == null) {
+            metadataScopes = new Domain(
+                    "metadata",
+                    "",
+                    ImmutableList.of(
+                            new GoogleOAuth2ScopeSpecification(getDescriptor().defaultScopes())));
+        }
+        return metadataScopes.test(requirements);
+    }
+
     @Nullable
-    public String defaultProject() {
-      try {
-        return getModule().getMetadataReader().readMetadata(PROJECT_ID_PATH);
-      } catch (ExecutorException | IOException e) {
-        return null;
-      }
+    private transient Domain metadataScopes;
+
+    /** {@inheritDoc} */
+    @Override
+    public String getUsername() {
+        try {
+            return getModule().getMetadataReader().readMetadata(IDENTITY_PATH);
+        } catch (ExecutorException | IOException e) {
+            throw new IllegalStateException(Messages.GoogleRobotMetadataCredentials_DefaultIdentityError(), e);
+        }
     }
 
     /**
-     * When we are running on GCE, we should be able to pre-populate the {@code projectId} field
-     * with the "right" project id.
-     *
-     * @return the project associated with this GCE instance, or null.
+     * The endpoint of the {@code METADATA_SERVER} for resolving the identity (email) of the service
+     * account.
      */
-    public List<String> defaultScopes() {
-      try {
-        String scopes = getModule().getMetadataReader().readMetadata(SCOPES_PATH);
+    private static final String IDENTITY_PATH = "/instance/service-accounts/default/email";
 
-        return Lists.newArrayList(Splitter.on('\n').trimResults().omitEmptyStrings().split(scopes));
-      } catch (ExecutorException | IOException e) {
-        return ImmutableList.of();
-      }
+    /** {@inheritDoc} */
+    @Override
+    public ComputeCredential getGoogleCredential(GoogleOAuth2ScopeRequirement requirement)
+            throws GeneralSecurityException {
+        // Ideally GCE would allow us to down-scope the metadata credentials we are
+        // providing a given library.
+        return new ComputeCredential(getModule().getHttpTransport(), getModule().getJsonFactory());
     }
 
-    /** This is the metadata endpoint for retrieving the project-id. */
-    private static final String PROJECT_ID_PATH = "/project/project-id";
+    /** {@inheritDoc} */
+    @Override
+    public Descriptor getDescriptor() {
+        return (Descriptor) super.getDescriptor();
+    }
 
-    /**
-     * This is the metadata endpoint for retrieving the set of oauth scopes to which the host
-     * instance is limited.
-     */
-    private static final String SCOPES_PATH = "/instance/service-accounts/default/scopes";
-  }
+    /** Descriptor for our unlimited service account extension. */
+    public static class Descriptor extends AbstractGoogleRobotCredentialsDescriptor {
+        /**
+         * This factory method determines whether the host machine has an associated metadata server,
+         * and if so registers the metadata-based robot credential.
+         */
+        @Extension
+        @Nullable
+        public static Descriptor metadataDescriptor() throws IOException {
+            if (disableForTesting) {
+                // For unit testing, we want to provide custom startup logic, in
+                // particular, we want to unconditionally instantiate it and do so with
+                // a module where we can mock out the MetadataReader's HttpTransport
+                // layer.
+                return null;
+            }
 
-  /** For {@link java.io.Serializable} */
-  private static final long serialVersionUID = 1L;
+            GoogleRobotMetadataCredentialsModule defaultModule = new GoogleRobotMetadataCredentialsModule();
+            if (defaultModule.getMetadataReader().hasMetadata()) {
+                // Otherwise only instantiate the metadata credential if we are on a
+                // machine with metadata.
+                return new Descriptor(defaultModule);
+            }
+            return null;
+        }
+
+        /** Used by unit testing to take control of how the descriptor is instantiated by Jenkins. */
+        @VisibleForTesting
+        static boolean disableForTesting = false;
+
+        @VisibleForTesting
+        Descriptor(GoogleRobotMetadataCredentialsModule module) {
+            super(GoogleRobotMetadataCredentials.class, module);
+        }
+
+        /** {@inheritDoc} */
+        @Override
+        public String getDisplayName() {
+            return Messages.GoogleRobotMetadataCredentials_DisplayName();
+        }
+
+        /** {@inheritDoc} */
+        @Override
+        public GoogleRobotMetadataCredentialsModule getModule() {
+            return (GoogleRobotMetadataCredentialsModule) super.getModule();
+        }
+
+        /**
+         * When we are running on GCE, we should be able to pre-populate the {@code projectId} field
+         * with the "right" project id.
+         *
+         * @return the project associated with this GCE instance, or null.
+         */
+        @Nullable
+        public String defaultProject() {
+            try {
+                return getModule().getMetadataReader().readMetadata(PROJECT_ID_PATH);
+            } catch (ExecutorException | IOException e) {
+                return null;
+            }
+        }
+
+        /**
+         * When we are running on GCE, we should be able to pre-populate the {@code projectId} field
+         * with the "right" project id.
+         *
+         * @return the project associated with this GCE instance, or null.
+         */
+        public List<String> defaultScopes() {
+            try {
+                String scopes = getModule().getMetadataReader().readMetadata(SCOPES_PATH);
+
+                return Lists.newArrayList(
+                        Splitter.on('\n').trimResults().omitEmptyStrings().split(scopes));
+            } catch (ExecutorException | IOException e) {
+                return ImmutableList.of();
+            }
+        }
+
+        /** This is the metadata endpoint for retrieving the project-id. */
+        private static final String PROJECT_ID_PATH = "/project/project-id";
+
+        /**
+         * This is the metadata endpoint for retrieving the set of oauth scopes to which the host
+         * instance is limited.
+         */
+        private static final String SCOPES_PATH = "/instance/service-accounts/default/scopes";
+    }
+
+    /** For {@link java.io.Serializable} */
+    private static final long serialVersionUID = 1L;
 }

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotMetadataCredentialsModule.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotMetadataCredentialsModule.java
@@ -22,11 +22,11 @@ import com.google.jenkins.plugins.util.MetadataReader;
  * GoogleRobotMetadataCredentials}.
  */
 public class GoogleRobotMetadataCredentialsModule extends GoogleRobotCredentialsModule {
-  /** Retrieve a MetadataReader for accessing stuff encoded in the instance metadata. */
-  public MetadataReader getMetadataReader() {
-    return new MetadataReader.Default();
-  }
+    /** Retrieve a MetadataReader for accessing stuff encoded in the instance metadata. */
+    public MetadataReader getMetadataReader() {
+        return new MetadataReader.Default();
+    }
 
-  /** For {@link java.io.Serializable} */
-  private static final long serialVersionUID = 1L;
+    /** For {@link java.io.Serializable} */
+    private static final long serialVersionUID = 1L;
 }

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotNameProvider.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotNameProvider.java
@@ -19,9 +19,9 @@ import com.cloudbees.plugins.credentials.CredentialsNameProvider;
 
 /** Retrieve a user-friendly name to be used when listing the credential for use by plugins. */
 public class GoogleRobotNameProvider extends CredentialsNameProvider<GoogleRobotCredentials> {
-  /** {@inheritDoc} */
-  @Override
-  public String getName(GoogleRobotCredentials credentials) {
-    return credentials.getProjectId();
-  }
+    /** {@inheritDoc} */
+    @Override
+    public String getName(GoogleRobotCredentials credentials) {
+        return credentials.getProjectId();
+    }
 }

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/JsonKey.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/JsonKey.java
@@ -43,35 +43,35 @@ import org.apache.commons.io.IOUtils;
  */
 @SuppressFBWarnings("EQ_DOESNT_OVERRIDE_EQUALS")
 public final class JsonKey extends GenericJson {
-  @Key("client_email")
-  private String clientEmail;
+    @Key("client_email")
+    private String clientEmail;
 
-  @Key("private_key")
-  private String privateKey;
+    @Key("private_key")
+    private String privateKey;
 
-  public static JsonKey load(JsonFactory jsonFactory, InputStream inputStream) throws IOException {
-    InputStreamReader reader = new InputStreamReader(inputStream, Charsets.UTF_8);
-    try {
-      Secret decoded = Secret.fromString(IOUtils.toString(reader));
-      return jsonFactory.fromString(decoded.getPlainText(), JsonKey.class);
-    } finally {
-      inputStream.close();
+    public static JsonKey load(JsonFactory jsonFactory, InputStream inputStream) throws IOException {
+        InputStreamReader reader = new InputStreamReader(inputStream, Charsets.UTF_8);
+        try {
+            Secret decoded = Secret.fromString(IOUtils.toString(reader));
+            return jsonFactory.fromString(decoded.getPlainText(), JsonKey.class);
+        } finally {
+            inputStream.close();
+        }
     }
-  }
 
-  public String getClientEmail() {
-    return clientEmail;
-  }
+    public String getClientEmail() {
+        return clientEmail;
+    }
 
-  public void setClientEmail(String clientEmail) {
-    this.clientEmail = clientEmail;
-  }
+    public void setClientEmail(String clientEmail) {
+        this.clientEmail = clientEmail;
+    }
 
-  public String getPrivateKey() {
-    return privateKey;
-  }
+    public String getPrivateKey() {
+        return privateKey;
+    }
 
-  public void setPrivateKey(String privateKey) {
-    this.privateKey = privateKey;
-  }
+    public void setPrivateKey(String privateKey) {
+        this.privateKey = privateKey;
+    }
 }

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/KeyUtils.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/KeyUtils.java
@@ -31,77 +31,76 @@ import org.apache.commons.io.IOUtils;
  */
 @Deprecated
 public class KeyUtils {
-  /** Utility class should never be instantiated. */
-  private KeyUtils() {}
+    /** Utility class should never be instantiated. */
+    private KeyUtils() {}
 
-  /**
-   * Creates a file with the given prefix/suffix in a standard Google auth directory, and sets the
-   * permissions of the file to owner-only read/write. Note: this doesn't work on Windows.
-   *
-   * @throws IOException if filesystem interaction fails.
-   */
-  public static File createKeyFile(String prefix, String suffix) throws IOException {
-    File keyFolder = new File(Jenkins.getInstance().getRootDir(), "gauth");
-    if (keyFolder.exists() || keyFolder.mkdirs()) {
-      File result = File.createTempFile(prefix, suffix, keyFolder);
-      if (result == null) {
-        throw new IOException("Failed to create key file");
-      }
-      updatePermissions(result);
-      return result;
-    } else {
-      throw new IOException("Failed to create key folder");
+    /**
+     * Creates a file with the given prefix/suffix in a standard Google auth directory, and sets the
+     * permissions of the file to owner-only read/write. Note: this doesn't work on Windows.
+     *
+     * @throws IOException if filesystem interaction fails.
+     */
+    public static File createKeyFile(String prefix, String suffix) throws IOException {
+        File keyFolder = new File(Jenkins.getInstance().getRootDir(), "gauth");
+        if (keyFolder.exists() || keyFolder.mkdirs()) {
+            File result = File.createTempFile(prefix, suffix, keyFolder);
+            if (result == null) {
+                throw new IOException("Failed to create key file");
+            }
+            updatePermissions(result);
+            return result;
+        } else {
+            throw new IOException("Failed to create key folder");
+        }
     }
-  }
 
-  /**
-   * Sets the permissions of the file to owner-only read/write. Note: this doesn't work on Windows.
-   *
-   * @throws IOException if filesystem interaction fails.
-   */
-  public static void updatePermissions(File file) throws IOException {
-    if (file == null || !file.exists()) {
-      return;
+    /**
+     * Sets the permissions of the file to owner-only read/write. Note: this doesn't work on Windows.
+     *
+     * @throws IOException if filesystem interaction fails.
+     */
+    public static void updatePermissions(File file) throws IOException {
+        if (file == null || !file.exists()) {
+            return;
+        }
+        // Set world read/write permissions to false.
+        // Set owner read/write permissions to true.
+        if (!file.setReadable(false, false)
+                || !file.setWritable(false, false)
+                || !file.setReadable(true, true)
+                || !file.setWritable(true, true)) {
+            throw new IOException("Failed to update key file permissions");
+        }
     }
-    // Set world read/write permissions to false.
-    // Set owner read/write permissions to true.
-    if (!file.setReadable(false, false)
-        || !file.setWritable(false, false)
-        || !file.setReadable(true, true)
-        || !file.setWritable(true, true)) {
-      throw new IOException("Failed to update key file permissions");
-    }
-  }
 
-  /**
-   * Writes the given key to the given keyfile, passing it through {@link Secret} to encode the
-   * string. Note that, per the documentation of {@link Secret}, this does not protect against an
-   * attacker who has full access to the local file system, but reduces the chance of accidental
-   * exposure.
-   */
-  public static void writeKeyToFileEncoded(String key, File file) throws IOException {
-    if (key == null || file == null) {
-      return;
+    /**
+     * Writes the given key to the given keyfile, passing it through {@link Secret} to encode the
+     * string. Note that, per the documentation of {@link Secret}, this does not protect against an
+     * attacker who has full access to the local file system, but reduces the chance of accidental
+     * exposure.
+     */
+    public static void writeKeyToFileEncoded(String key, File file) throws IOException {
+        if (key == null || file == null) {
+            return;
+        }
+        Secret encoded = Secret.fromString(key);
+        writeKeyToFile(IOUtils.toInputStream(encoded.getEncryptedValue(), StandardCharsets.UTF_8), file);
     }
-    Secret encoded = Secret.fromString(key);
-    writeKeyToFile(
-        IOUtils.toInputStream(encoded.getEncryptedValue(), StandardCharsets.UTF_8), file);
-  }
 
-  /**
-   * Writes the key contained in the given {@link InputStream} to the given keyfile. Does not close
-   * the input stream.
-   */
-  public static void writeKeyToFile(InputStream keyStream, File file) throws IOException {
-    if (keyStream == null || file == null) {
-      return;
+    /**
+     * Writes the key contained in the given {@link InputStream} to the given keyfile. Does not close
+     * the input stream.
+     */
+    public static void writeKeyToFile(InputStream keyStream, File file) throws IOException {
+        if (keyStream == null || file == null) {
+            return;
+        }
+        FileOutputStream out = null;
+        try {
+            out = new FileOutputStream(file);
+            IOUtils.copy(keyStream, out);
+        } finally {
+            IOUtils.closeQuietly(out);
+        }
     }
-    FileOutputStream out = null;
-    try {
-      out = new FileOutputStream(file);
-      IOUtils.copy(keyStream, out);
-    } finally {
-      IOUtils.closeQuietly(out);
-    }
-  }
 }

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/LegacyJsonKey.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/LegacyJsonKey.java
@@ -37,37 +37,37 @@ import java.io.InputStream;
 @SuppressFBWarnings("EQ_DOESNT_OVERRIDE_EQUALS")
 public final class LegacyJsonKey extends GenericJson {
 
-  /** Details for web applications. */
-  @Key private Details web;
+    /** Details for web applications. */
+    @Key
+    private Details web;
 
-  /** Returns the details for web applications. */
-  public Details getWeb() {
-    return web;
-  }
-
-  public void setWeb(Details web) {
-    this.web = web;
-  }
-
-  /** Container for our new field, modeled after: {@link GoogleClientSecrets.Details} */
-  public static final class Details extends GenericJson {
-    /** Client email. */
-    @Key("client_email")
-    private String clientEmail;
-
-    public void setClientEmail(String clientEmail) {
-      this.clientEmail = clientEmail;
+    /** Returns the details for web applications. */
+    public Details getWeb() {
+        return web;
     }
 
-    /** Returns the client email. */
-    public String getClientEmail() {
-      return clientEmail;
+    public void setWeb(Details web) {
+        this.web = web;
     }
-  }
 
-  /** Loads the {@code client_secrets.json} file from the given input stream. */
-  public static LegacyJsonKey load(JsonFactory jsonFactory, InputStream inputStream)
-      throws IOException {
-    return jsonFactory.fromInputStream(inputStream, Charsets.UTF_8, LegacyJsonKey.class);
-  }
+    /** Container for our new field, modeled after: {@link GoogleClientSecrets.Details} */
+    public static final class Details extends GenericJson {
+        /** Client email. */
+        @Key("client_email")
+        private String clientEmail;
+
+        public void setClientEmail(String clientEmail) {
+            this.clientEmail = clientEmail;
+        }
+
+        /** Returns the client email. */
+        public String getClientEmail() {
+            return clientEmail;
+        }
+    }
+
+    /** Loads the {@code client_secrets.json} file from the given input stream. */
+    public static LegacyJsonKey load(JsonFactory jsonFactory, InputStream inputStream) throws IOException {
+        return jsonFactory.fromInputStream(inputStream, Charsets.UTF_8, LegacyJsonKey.class);
+    }
 }

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/RemotableGoogleCredentials.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/RemotableGoogleCredentials.java
@@ -38,125 +38,122 @@ import org.joda.time.DateTime;
  * @author Matt Moore
  */
 final class RemotableGoogleCredentials extends GoogleRobotCredentials {
-  /**
-   * Construct a remotable credential. This should never be used directly, which is why this class
-   * is {@code package-private}. This should only be called from {@link
-   * GoogleRobotCredentials#forRemote}.
-   */
-  @SuppressFBWarnings(
-      value = "NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE",
-      justification = "False positive from what I can see in Ordering.natural().nullsFirst()")
-  public RemotableGoogleCredentials(
-      GoogleRobotCredentials credentials,
-      GoogleOAuth2ScopeRequirement requirement,
-      GoogleRobotCredentialsModule module)
-      throws GeneralSecurityException {
-    super(
-        credentials.getScope() == null ? CredentialsScope.GLOBAL : credentials.getScope(),
-        "",
-        checkNotNull(credentials).getProjectId(),
-        checkNotNull(module));
+    /**
+     * Construct a remotable credential. This should never be used directly, which is why this class
+     * is {@code package-private}. This should only be called from {@link
+     * GoogleRobotCredentials#forRemote}.
+     */
+    @SuppressFBWarnings(
+            value = "NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE",
+            justification = "False positive from what I can see in Ordering.natural().nullsFirst()")
+    public RemotableGoogleCredentials(
+            GoogleRobotCredentials credentials,
+            GoogleOAuth2ScopeRequirement requirement,
+            GoogleRobotCredentialsModule module)
+            throws GeneralSecurityException {
+        super(
+                credentials.getScope() == null ? CredentialsScope.GLOBAL : credentials.getScope(),
+                "",
+                checkNotNull(credentials).getProjectId(),
+                checkNotNull(module));
 
-    this.username = credentials.getUsername();
+        this.username = credentials.getUsername();
 
-    // Eagerly create the access token we will use on the remote machine.
-    Credential credential = credentials.getGoogleCredential(checkNotNull(requirement));
-    try {
-      Long rawExpiration = credential.getExpiresInSeconds();
+        // Eagerly create the access token we will use on the remote machine.
+        Credential credential = credentials.getGoogleCredential(checkNotNull(requirement));
+        try {
+            Long rawExpiration = credential.getExpiresInSeconds();
 
-      if (Ordering.natural().nullsFirst().compare(rawExpiration, MINIMUM_DURATION_SECONDS) < 0) {
-        if (!credential.refreshToken()) {
-          throw new GeneralSecurityException(Messages.RemotableGoogleCredentials_NoAccessToken());
+            if (Ordering.natural().nullsFirst().compare(rawExpiration, MINIMUM_DURATION_SECONDS) < 0) {
+                if (!credential.refreshToken()) {
+                    throw new GeneralSecurityException(Messages.RemotableGoogleCredentials_NoAccessToken());
+                }
+            }
+        } catch (IOException e) {
+            throw new GeneralSecurityException(Messages.RemotableGoogleCredentials_NoAccessToken(), e);
         }
-      }
-    } catch (IOException e) {
-      throw new GeneralSecurityException(Messages.RemotableGoogleCredentials_NoAccessToken(), e);
+        this.accessToken = checkNotNull(credential.getAccessToken());
+        this.expiration = new DateTime()
+                .plusSeconds(checkNotNull(credential.getExpiresInSeconds()).intValue())
+                .getMillis();
     }
-    this.accessToken = checkNotNull(credential.getAccessToken());
-    this.expiration =
-        new DateTime()
-            .plusSeconds(checkNotNull(credential.getExpiresInSeconds()).intValue())
-            .getMillis();
-  }
-  /**
-   * Construct a remotable credential. This should never be used directly - this constructor is only
-   * for migrating old credentials that had no id and relied on the projectId during readResolve().
-   */
-  private RemotableGoogleCredentials(
-      CredentialsScope scope,
-      String id,
-      String projectId,
-      String description,
-      GoogleRobotCredentialsModule module,
-      String username,
-      String accessToken,
-      long expiration) {
-    super(scope, id, projectId, description, module);
-    this.username = username;
-    this.accessToken = accessToken;
-    this.expiration = expiration;
-  }
+    /**
+     * Construct a remotable credential. This should never be used directly - this constructor is only
+     * for migrating old credentials that had no id and relied on the projectId during readResolve().
+     */
+    private RemotableGoogleCredentials(
+            CredentialsScope scope,
+            String id,
+            String projectId,
+            String description,
+            GoogleRobotCredentialsModule module,
+            String username,
+            String accessToken,
+            long expiration) {
+        super(scope, id, projectId, description, module);
+        this.username = username;
+        this.accessToken = accessToken;
+        this.expiration = expiration;
+    }
 
-  @SuppressFBWarnings(
-      value = "RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE",
-      justification =
-          "for migrating older credentials that did not have a separate id field, and would really "
-              + "have a null id when attempted to deserialize. readResolve overwrites these nulls")
-  private Object readResolve() throws Exception {
-    return new RemotableGoogleCredentials(
-        getScope() == null ? CredentialsScope.GLOBAL : getScope(),
-        getId() == null ? getProjectId() : getId(),
-        getProjectId(),
-        getDescription(),
-        getModule(),
-        username,
-        accessToken,
-        expiration);
-  }
+    @SuppressFBWarnings(
+            value = "RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE",
+            justification = "for migrating older credentials that did not have a separate id field, and would really "
+                    + "have a null id when attempted to deserialize. readResolve overwrites these nulls")
+    private Object readResolve() throws Exception {
+        return new RemotableGoogleCredentials(
+                getScope() == null ? CredentialsScope.GLOBAL : getScope(),
+                getId() == null ? getProjectId() : getId(),
+                getProjectId(),
+                getDescription(),
+                getModule(),
+                username,
+                accessToken,
+                expiration);
+    }
 
-  /** {@inheritDoc} */
-  @Override
-  public AbstractGoogleRobotCredentialsDescriptor getDescriptor() {
-    throw new UnsupportedOperationException(Messages.RemotableGoogleCredentials_BadGetDescriptor());
-  }
+    /** {@inheritDoc} */
+    @Override
+    public AbstractGoogleRobotCredentialsDescriptor getDescriptor() {
+        throw new UnsupportedOperationException(Messages.RemotableGoogleCredentials_BadGetDescriptor());
+    }
 
-  /** {@inheritDoc} */
-  @Override
-  public String getUsername() {
-    return username;
-  }
+    /** {@inheritDoc} */
+    @Override
+    public String getUsername() {
+        return username;
+    }
 
-  /** {@inheritDoc} */
-  @Override
-  public Credential getGoogleCredential(GoogleOAuth2ScopeRequirement requirement)
-      throws GeneralSecurityException {
-    // Return a credential synthesized from our stored access token
-    // and expiration.
-    //
-    // TODO(mattmoor): Consider throwing an exception if the access token
-    // has expired.
-    long lifetimeSeconds = (expiration - new DateTime().getMillis()) / 1000;
+    /** {@inheritDoc} */
+    @Override
+    public Credential getGoogleCredential(GoogleOAuth2ScopeRequirement requirement) throws GeneralSecurityException {
+        // Return a credential synthesized from our stored access token
+        // and expiration.
+        //
+        // TODO(mattmoor): Consider throwing an exception if the access token
+        // has expired.
+        long lifetimeSeconds = (expiration - new DateTime().getMillis()) / 1000;
 
-    return new GoogleCredential.Builder()
-        .setTransport(getModule().getHttpTransport())
-        .setJsonFactory(getModule().getJsonFactory())
-        .build()
-        .setAccessToken(accessToken)
-        .setExpiresInSeconds(lifetimeSeconds);
-  }
+        return new GoogleCredential.Builder()
+                .setTransport(getModule().getHttpTransport())
+                .setJsonFactory(getModule().getJsonFactory())
+                .build()
+                .setAccessToken(accessToken)
+                .setExpiresInSeconds(lifetimeSeconds);
+    }
 
-  /** The identity of the credential. */
-  private final String username;
+    /** The identity of the credential. */
+    private final String username;
 
-  /** The access token eagerly retrieved from the original credential. */
-  private final String accessToken;
+    /** The access token eagerly retrieved from the original credential. */
+    private final String accessToken;
 
-  /** The time at which the accessToken will expire. */
-  private final long expiration;
+    /** The time at which the accessToken will expire. */
+    private final long expiration;
 
-  /**
-   * The minimum duration {@code 5 minutes} to allow for an access token before attempting to
-   * refresh it.
-   */
-  private static final Long MINIMUM_DURATION_SECONDS = 300L;
+    /**
+     * The minimum duration {@code 5 minutes} to allow for an access token before attempting to
+     * refresh it.
+     */
+    private static final Long MINIMUM_DURATION_SECONDS = 300L;
 }

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/ServiceAccountConfig.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/ServiceAccountConfig.java
@@ -32,33 +32,32 @@ import org.apache.commons.io.FileUtils;
  * general abstraction for providing google service account authentication mechanism. subclasses
  * need to provide an accountId and a private key to use for authenticating a service account
  */
-public abstract class ServiceAccountConfig
-    implements Describable<ServiceAccountConfig>, Serializable {
-  private static final Logger LOGGER = Logger.getLogger(ServiceAccountConfig.class.getName());
-  private static final long serialVersionUID = 6355493019938144806L;
+public abstract class ServiceAccountConfig implements Describable<ServiceAccountConfig>, Serializable {
+    private static final Logger LOGGER = Logger.getLogger(ServiceAccountConfig.class.getName());
+    private static final long serialVersionUID = 6355493019938144806L;
 
-  public abstract String getAccountId();
+    public abstract String getAccountId();
 
-  public abstract PrivateKey getPrivateKey();
+    public abstract PrivateKey getPrivateKey();
 
-  @Deprecated // Used only for compatibility purposes.
-  @CheckForNull
-  protected SecretBytes getSecretBytesFromFile(@CheckForNull String filePath) {
-    Jenkins.get().checkPermission(Jenkins.RUN_SCRIPTS);
+    @Deprecated // Used only for compatibility purposes.
+    @CheckForNull
+    protected SecretBytes getSecretBytesFromFile(@CheckForNull String filePath) {
+        Jenkins.get().checkPermission(Jenkins.RUN_SCRIPTS);
 
-    if (Strings.isNullOrEmpty(filePath)) {
-      LOGGER.log(Level.SEVERE, "Provided file path is null or empty.");
-      return null;
+        if (Strings.isNullOrEmpty(filePath)) {
+            LOGGER.log(Level.SEVERE, "Provided file path is null or empty.");
+            return null;
+        }
+
+        try {
+            return SecretBytes.fromBytes(FileUtils.readFileToByteArray(new File(filePath)));
+        } catch (IOException e) {
+            LOGGER.log(Level.SEVERE, String.format("Failed to read previous key from %s", filePath), e);
+            return null;
+        }
     }
 
-    try {
-      return SecretBytes.fromBytes(FileUtils.readFileToByteArray(new File(filePath)));
-    } catch (IOException e) {
-      LOGGER.log(Level.SEVERE, String.format("Failed to read previous key from %s", filePath), e);
-      return null;
-    }
-  }
-
-  /** abstract descriptor for service account authentication */
-  public abstract static class Descriptor extends hudson.model.Descriptor<ServiceAccountConfig> {}
+    /** abstract descriptor for service account authentication */
+    public abstract static class Descriptor extends hudson.model.Descriptor<ServiceAccountConfig> {}
 }

--- a/src/main/java/com/google/jenkins/plugins/util/ConflictException.java
+++ b/src/main/java/com/google/jenkins/plugins/util/ConflictException.java
@@ -17,9 +17,9 @@ package com.google.jenkins.plugins.util;
 
 /** This exception is used to wrap and propagate 409 (Conflict) HTTP exceptions up the stack. */
 public class ConflictException extends ExecutorException {
-  public ConflictException(Throwable throwable) {
-    super(throwable);
-  }
+    public ConflictException(Throwable throwable) {
+        super(throwable);
+    }
 
-  public ConflictException() {}
+    public ConflictException() {}
 }

--- a/src/main/java/com/google/jenkins/plugins/util/ExecutorException.java
+++ b/src/main/java/com/google/jenkins/plugins/util/ExecutorException.java
@@ -21,9 +21,9 @@ package com.google.jenkins.plugins.util;
  * of exceptions may be safely handled while letting these propagate.
  */
 public abstract class ExecutorException extends Exception {
-  public ExecutorException(Throwable throwable) {
-    super(throwable);
-  }
+    public ExecutorException(Throwable throwable) {
+        super(throwable);
+    }
 
-  public ExecutorException() {}
+    public ExecutorException() {}
 }

--- a/src/main/java/com/google/jenkins/plugins/util/ForbiddenException.java
+++ b/src/main/java/com/google/jenkins/plugins/util/ForbiddenException.java
@@ -17,9 +17,9 @@ package com.google.jenkins.plugins.util;
 
 /** This exception is used to wrap and propagate 403 (Forbidden) HTTP exceptions up the stack. */
 public class ForbiddenException extends ExecutorException {
-  public ForbiddenException(Throwable throwable) {
-    super(throwable);
-  }
+    public ForbiddenException(Throwable throwable) {
+        super(throwable);
+    }
 
-  public ForbiddenException() {}
+    public ForbiddenException() {}
 }

--- a/src/main/java/com/google/jenkins/plugins/util/MaxRetryExceededException.java
+++ b/src/main/java/com/google/jenkins/plugins/util/MaxRetryExceededException.java
@@ -20,9 +20,9 @@ package com.google.jenkins.plugins.util;
  * shouldn't make further attempt.
  */
 public class MaxRetryExceededException extends ExecutorException {
-  public MaxRetryExceededException(Throwable throwable) {
-    super(throwable);
-  }
+    public MaxRetryExceededException(Throwable throwable) {
+        super(throwable);
+    }
 
-  public MaxRetryExceededException() {}
+    public MaxRetryExceededException() {}
 }

--- a/src/main/java/com/google/jenkins/plugins/util/MetadataReader.java
+++ b/src/main/java/com/google/jenkins/plugins/util/MetadataReader.java
@@ -39,80 +39,79 @@ import org.apache.commons.io.IOUtils;
  * @author Matt Moore
  */
 public interface MetadataReader {
-  /** Are we on a Google Compute Engine instance? */
-  boolean hasMetadata() throws IOException;
-
-  /**
-   * Reads the specified sub-element out of the Google Compute Engine instance's metadata. These
-   * relative paths are expected to start with:
-   *
-   * <ul>
-   *   <li>/instance/...
-   *   <li>/project/...
-   * </ul>
-   */
-  String readMetadata(String metadataPath) throws IOException, ExecutorException;
-
-  /** A simple default implementation that reads metadata via http requests. */
-  public static class Default implements MetadataReader {
-    public Default() {
-      this(new NetHttpTransport().createRequestFactory());
-    }
-
-    public Default(HttpRequestFactory requestFactory) {
-      this.requestFactory = checkNotNull(requestFactory);
-    }
-
-    private final HttpRequestFactory requestFactory;
-
-    /** {@inheritDoc} */
-    @Override
-    public String readMetadata(String metadataPath) throws IOException, ExecutorException {
-      HttpRequest request =
-          requestFactory.buildGetRequest(new GenericUrl(METADATA_SERVER + metadataPath));
-
-      // GCE v1 requires requests to the metadata service to specify
-      // this header in order to get anything back.
-      request.getHeaders().set("Metadata-Flavor", "Google");
-
-      HttpResponse response;
-      try {
-        response = request.execute();
-      } catch (HttpResponseException e) {
-        switch (e.getStatusCode()) {
-          case STATUS_CODE_UNAUTHORIZED:
-          case STATUS_CODE_FORBIDDEN:
-            throw new ForbiddenException(e);
-          case STATUS_CODE_NOT_FOUND:
-            throw new NotFoundException(e);
-          default:
-            throw e;
-        }
-      }
-
-      try (InputStreamReader inChars =
-          new InputStreamReader(checkNotNull(response.getContent()), Charsets.UTF_8)) {
-        StringWriter output = new StringWriter();
-        IOUtils.copy(inChars, output);
-        return output.toString();
-      }
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public boolean hasMetadata() {
-      try {
-        readMetadata("");
-        return true;
-      } catch (IOException | ExecutorException e) {
-        return false;
-      }
-    }
+    /** Are we on a Google Compute Engine instance? */
+    boolean hasMetadata() throws IOException;
 
     /**
-     * The address of the GCE Metadata service that provides GCE instances with information about
-     * the default service account.
+     * Reads the specified sub-element out of the Google Compute Engine instance's metadata. These
+     * relative paths are expected to start with:
+     *
+     * <ul>
+     *   <li>/instance/...
+     *   <li>/project/...
+     * </ul>
      */
-    public static final String METADATA_SERVER = "http://metadata/computeMetadata/v1";
-  }
+    String readMetadata(String metadataPath) throws IOException, ExecutorException;
+
+    /** A simple default implementation that reads metadata via http requests. */
+    public static class Default implements MetadataReader {
+        public Default() {
+            this(new NetHttpTransport().createRequestFactory());
+        }
+
+        public Default(HttpRequestFactory requestFactory) {
+            this.requestFactory = checkNotNull(requestFactory);
+        }
+
+        private final HttpRequestFactory requestFactory;
+
+        /** {@inheritDoc} */
+        @Override
+        public String readMetadata(String metadataPath) throws IOException, ExecutorException {
+            HttpRequest request = requestFactory.buildGetRequest(new GenericUrl(METADATA_SERVER + metadataPath));
+
+            // GCE v1 requires requests to the metadata service to specify
+            // this header in order to get anything back.
+            request.getHeaders().set("Metadata-Flavor", "Google");
+
+            HttpResponse response;
+            try {
+                response = request.execute();
+            } catch (HttpResponseException e) {
+                switch (e.getStatusCode()) {
+                    case STATUS_CODE_UNAUTHORIZED:
+                    case STATUS_CODE_FORBIDDEN:
+                        throw new ForbiddenException(e);
+                    case STATUS_CODE_NOT_FOUND:
+                        throw new NotFoundException(e);
+                    default:
+                        throw e;
+                }
+            }
+
+            try (InputStreamReader inChars =
+                    new InputStreamReader(checkNotNull(response.getContent()), Charsets.UTF_8)) {
+                StringWriter output = new StringWriter();
+                IOUtils.copy(inChars, output);
+                return output.toString();
+            }
+        }
+
+        /** {@inheritDoc} */
+        @Override
+        public boolean hasMetadata() {
+            try {
+                readMetadata("");
+                return true;
+            } catch (IOException | ExecutorException e) {
+                return false;
+            }
+        }
+
+        /**
+         * The address of the GCE Metadata service that provides GCE instances with information about
+         * the default service account.
+         */
+        public static final String METADATA_SERVER = "http://metadata/computeMetadata/v1";
+    }
 }

--- a/src/main/java/com/google/jenkins/plugins/util/MockExecutor.java
+++ b/src/main/java/com/google/jenkins/plugins/util/MockExecutor.java
@@ -34,172 +34,169 @@ import java.util.LinkedList;
  * </ul>
  */
 public class MockExecutor extends Executor {
-  public MockExecutor() {
-    requestTypes = new LinkedList<>();
-    responses = new LinkedList<>();
-    exceptions = new LinkedList<>();
-    predicates = new LinkedList<>();
-    sawUnexpected = false;
-  }
-
-  /** {@inheritDoc} */
-  @Override
-  public void sleep() {
-    // Never sleep, this is a test library, we want fast tests.
-  }
-
-  /** {@inheritDoc} */
-  @Override
-  public <T> T execute(RequestCallable<T> request) throws IOException, ExecutorException {
-    // TODO(nghia): Think about implementing this.
-    throw new UnsupportedOperationException();
-  }
-
-  /** {@inheritDoc} */
-  @Override
-  public <T> T execute(AbstractGoogleJsonClientRequest<T> request)
-      throws IOException, ExecutorException {
-    Class<?> requestClass = request.getClass();
-    if (requestTypes.isEmpty()) {
-      sawUnexpected = true;
-      throw new IllegalStateException("Unexpected request: " + requestClass);
+    public MockExecutor() {
+        requestTypes = new LinkedList<>();
+        responses = new LinkedList<>();
+        exceptions = new LinkedList<>();
+        predicates = new LinkedList<>();
+        sawUnexpected = false;
     }
 
-    // Remove all three states to keep the lists in sync
-    Class<?> clazz = requestTypes.removeFirst();
-    Object response = responses.removeFirst();
-    Exception exception = exceptions.removeFirst();
-    Predicate<AbstractGoogleJsonClientRequest<T>> predicate =
-        (Predicate<AbstractGoogleJsonClientRequest<T>>) predicates.removeFirst();
-
-    if (requestClass != clazz) {
-      sawUnexpected = true;
-      throw new IllegalStateException(
-          "Unexpected (or out of order) request: " + requestClass + " expected: " + clazz);
+    /** {@inheritDoc} */
+    @Override
+    public void sleep() {
+        // Never sleep, this is a test library, we want fast tests.
     }
 
-    if (!predicate.apply(request)) {
-      sawUnexpected = true;
-      throw new IllegalStateException(
-          "User predicate: " + predicate + " failed for request: " + requestClass);
+    /** {@inheritDoc} */
+    @Override
+    public <T> T execute(RequestCallable<T> request) throws IOException, ExecutorException {
+        // TODO(nghia): Think about implementing this.
+        throw new UnsupportedOperationException();
     }
 
-    if (response == null) {
-      if (exception != null) {
-        if (exception instanceof IOException) {
-          throw (IOException) exception; // throwWhen(IOException)
-        } else {
-          throw (ExecutorException) exception; // throwWhen(ExecutorException)
+    /** {@inheritDoc} */
+    @Override
+    public <T> T execute(AbstractGoogleJsonClientRequest<T> request) throws IOException, ExecutorException {
+        Class<?> requestClass = request.getClass();
+        if (requestTypes.isEmpty()) {
+            sawUnexpected = true;
+            throw new IllegalStateException("Unexpected request: " + requestClass);
         }
-      }
-      return (T) request.getJsonContent(); // passThruWhen
+
+        // Remove all three states to keep the lists in sync
+        Class<?> clazz = requestTypes.removeFirst();
+        Object response = responses.removeFirst();
+        Exception exception = exceptions.removeFirst();
+        Predicate<AbstractGoogleJsonClientRequest<T>> predicate =
+                (Predicate<AbstractGoogleJsonClientRequest<T>>) predicates.removeFirst();
+
+        if (requestClass != clazz) {
+            sawUnexpected = true;
+            throw new IllegalStateException(
+                    "Unexpected (or out of order) request: " + requestClass + " expected: " + clazz);
+        }
+
+        if (!predicate.apply(request)) {
+            sawUnexpected = true;
+            throw new IllegalStateException("User predicate: " + predicate + " failed for request: " + requestClass);
+        }
+
+        if (response == null) {
+            if (exception != null) {
+                if (exception instanceof IOException) {
+                    throw (IOException) exception; // throwWhen(IOException)
+                } else {
+                    throw (ExecutorException) exception; // throwWhen(ExecutorException)
+                }
+            }
+            return (T) request.getJsonContent(); // passThruWhen
+        }
+        return (T) response; // when
     }
-    return (T) response; // when
-  }
 
-  /**
-   * When the next request matches the given {@code requestType} and the provided user {@link
-   * Predicate} return {@code response} as the response.
-   */
-  public <T, S extends AbstractGoogleJsonClientRequest<T>, C extends S> void when(
-      Class<C> requestType, T response, Predicate<S> predicate) {
-    requestTypes.add(checkNotNull(requestType));
-    responses.add(response); // must allow null for delete's Void return type
-    exceptions.add(null);
-    predicates.add(checkNotNull(predicate));
-  }
+    /**
+     * When the next request matches the given {@code requestType} and the provided user {@link
+     * Predicate} return {@code response} as the response.
+     */
+    public <T, S extends AbstractGoogleJsonClientRequest<T>, C extends S> void when(
+            Class<C> requestType, T response, Predicate<S> predicate) {
+        requestTypes.add(checkNotNull(requestType));
+        responses.add(response); // must allow null for delete's Void return type
+        exceptions.add(null);
+        predicates.add(checkNotNull(predicate));
+    }
 
-  /**
-   * When the next request matches the given {@code requestType} return {@code response} as the
-   * response.
-   */
-  public <T, C extends AbstractGoogleJsonClientRequest<T>> void when(
-      Class<C> requestType, T response) {
-    when(requestType, response, Predicates.alwaysTrue());
-  }
+    /**
+     * When the next request matches the given {@code requestType} return {@code response} as the
+     * response.
+     */
+    public <T, C extends AbstractGoogleJsonClientRequest<T>> void when(Class<C> requestType, T response) {
+        when(requestType, response, Predicates.alwaysTrue());
+    }
 
-  /**
-   * When the next request matches the given {@code requestType} and the provided user {@link
-   * Predicate} throw {@code exception} instead of responding.
-   */
-  public <T, S extends AbstractGoogleJsonClientRequest<T>, C extends S> void throwWhen(
-      Class<C> requestType, IOException exception, Predicate<S> predicate) {
-    throwWhenInternal(requestType, exception, predicate);
-  }
+    /**
+     * When the next request matches the given {@code requestType} and the provided user {@link
+     * Predicate} throw {@code exception} instead of responding.
+     */
+    public <T, S extends AbstractGoogleJsonClientRequest<T>, C extends S> void throwWhen(
+            Class<C> requestType, IOException exception, Predicate<S> predicate) {
+        throwWhenInternal(requestType, exception, predicate);
+    }
 
-  /**
-   * When the next request matches the given {@code requestType} throw {@code exception} instead of
-   * responding.
-   */
-  public <T, C extends AbstractGoogleJsonClientRequest<T>> void throwWhen(
-      Class<C> requestType, IOException exception) {
-    throwWhen(requestType, exception, Predicates.alwaysTrue());
-  }
+    /**
+     * When the next request matches the given {@code requestType} throw {@code exception} instead of
+     * responding.
+     */
+    public <T, C extends AbstractGoogleJsonClientRequest<T>> void throwWhen(
+            Class<C> requestType, IOException exception) {
+        throwWhen(requestType, exception, Predicates.alwaysTrue());
+    }
 
-  /**
-   * When the next request matches the given {@code requestType} and the provided user {@link
-   * Predicate} throw {@code exception} instead of responding.
-   */
-  public <T, S extends AbstractGoogleJsonClientRequest<T>, C extends S> void throwWhen(
-      Class<C> requestType, ExecutorException exception, Predicate<S> predicate) {
-    throwWhenInternal(requestType, exception, predicate);
-  }
+    /**
+     * When the next request matches the given {@code requestType} and the provided user {@link
+     * Predicate} throw {@code exception} instead of responding.
+     */
+    public <T, S extends AbstractGoogleJsonClientRequest<T>, C extends S> void throwWhen(
+            Class<C> requestType, ExecutorException exception, Predicate<S> predicate) {
+        throwWhenInternal(requestType, exception, predicate);
+    }
 
-  /**
-   * When the next request matches the given {@code requestType} throw {@code exception} instead of
-   * responding.
-   */
-  public <T, C extends AbstractGoogleJsonClientRequest<T>> void throwWhen(
-      Class<C> requestType, ExecutorException exception) {
-    throwWhen(requestType, exception, Predicates.alwaysTrue());
-  }
+    /**
+     * When the next request matches the given {@code requestType} throw {@code exception} instead of
+     * responding.
+     */
+    public <T, C extends AbstractGoogleJsonClientRequest<T>> void throwWhen(
+            Class<C> requestType, ExecutorException exception) {
+        throwWhen(requestType, exception, Predicates.alwaysTrue());
+    }
 
-  /**
-   * When the next request matches the given {@code requestType} and the provided user {@link
-   * Predicate} throw {@code exception} instead of responding.
-   */
-  private <T, S extends AbstractGoogleJsonClientRequest<T>, C extends S> void throwWhenInternal(
-      Class<C> requestType, Exception exception, Predicate<S> predicate) {
-    requestTypes.add(checkNotNull(requestType));
-    responses.add(null);
-    exceptions.add(exception);
-    predicates.add(checkNotNull(predicate));
-  }
+    /**
+     * When the next request matches the given {@code requestType} and the provided user {@link
+     * Predicate} throw {@code exception} instead of responding.
+     */
+    private <T, S extends AbstractGoogleJsonClientRequest<T>, C extends S> void throwWhenInternal(
+            Class<C> requestType, Exception exception, Predicate<S> predicate) {
+        requestTypes.add(checkNotNull(requestType));
+        responses.add(null);
+        exceptions.add(exception);
+        predicates.add(checkNotNull(predicate));
+    }
 
-  /**
-   * When the next request matches the given {@code requestType} and the provided user {@link
-   * Predicate} pass through the request's {@code getJsonContent()} cast to the expected response
-   * type.
-   */
-  public <T, S extends AbstractGoogleJsonClientRequest<T>, C extends S> void passThruWhen(
-      Class<C> requestType, Predicate<S> predicate) {
-    requestTypes.add(checkNotNull(requestType));
-    responses.add(null);
-    exceptions.add(null);
-    predicates.add(checkNotNull(predicate));
-  }
+    /**
+     * When the next request matches the given {@code requestType} and the provided user {@link
+     * Predicate} pass through the request's {@code getJsonContent()} cast to the expected response
+     * type.
+     */
+    public <T, S extends AbstractGoogleJsonClientRequest<T>, C extends S> void passThruWhen(
+            Class<C> requestType, Predicate<S> predicate) {
+        requestTypes.add(checkNotNull(requestType));
+        responses.add(null);
+        exceptions.add(null);
+        predicates.add(checkNotNull(predicate));
+    }
 
-  /**
-   * When the next request matches the given {@code requestType} pass through the request's {@code
-   * getJsonContent()} cast to the expected response type.
-   */
-  public <T, C extends AbstractGoogleJsonClientRequest<T>> void passThruWhen(Class<C> requestType) {
-    passThruWhen(requestType, Predicates.alwaysTrue());
-  }
+    /**
+     * When the next request matches the given {@code requestType} pass through the request's {@code
+     * getJsonContent()} cast to the expected response type.
+     */
+    public <T, C extends AbstractGoogleJsonClientRequest<T>> void passThruWhen(Class<C> requestType) {
+        passThruWhen(requestType, Predicates.alwaysTrue());
+    }
 
-  /** Did we see all of the expected requests? */
-  public boolean sawAll() {
-    return requestTypes.isEmpty();
-  }
+    /** Did we see all of the expected requests? */
+    public boolean sawAll() {
+        return requestTypes.isEmpty();
+    }
 
-  /** Did we see any unexpected requests? */
-  public boolean sawUnexpected() {
-    return sawUnexpected;
-  }
+    /** Did we see any unexpected requests? */
+    public boolean sawUnexpected() {
+        return sawUnexpected;
+    }
 
-  private final LinkedList<Class<?>> requestTypes;
-  private final LinkedList<Object> responses;
-  private final LinkedList<Exception> exceptions;
-  private final LinkedList<Predicate<?>> predicates;
-  private boolean sawUnexpected;
+    private final LinkedList<Class<?>> requestTypes;
+    private final LinkedList<Object> responses;
+    private final LinkedList<Exception> exceptions;
+    private final LinkedList<Predicate<?>> predicates;
+    private boolean sawUnexpected;
 }

--- a/src/main/java/com/google/jenkins/plugins/util/NameValuePair.java
+++ b/src/main/java/com/google/jenkins/plugins/util/NameValuePair.java
@@ -24,22 +24,22 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * @param <V> The type for the value
  */
 public class NameValuePair<N, V> {
-  /** Construct a pair from the given name and value. */
-  public NameValuePair(N name, V value) {
-    this.name = checkNotNull(name);
-    this.value = checkNotNull(value);
-  }
+    /** Construct a pair from the given name and value. */
+    public NameValuePair(N name, V value) {
+        this.name = checkNotNull(name);
+        this.value = checkNotNull(value);
+    }
 
-  /** Fetches the name */
-  public N getName() {
-    return this.name;
-  }
+    /** Fetches the name */
+    public N getName() {
+        return this.name;
+    }
 
-  /** Fetches the value */
-  public V getValue() {
-    return this.value;
-  }
+    /** Fetches the value */
+    public V getValue() {
+        return this.value;
+    }
 
-  private final N name;
-  private final V value;
+    private final N name;
+    private final V value;
 }

--- a/src/main/java/com/google/jenkins/plugins/util/NotFoundException.java
+++ b/src/main/java/com/google/jenkins/plugins/util/NotFoundException.java
@@ -17,9 +17,9 @@ package com.google.jenkins.plugins.util;
 
 /** This exception is used to wrap and propagate 404 (Not Found) HTTP exceptions up the stack. */
 public class NotFoundException extends ExecutorException {
-  public NotFoundException(Throwable throwable) {
-    super(throwable);
-  }
+    public NotFoundException(Throwable throwable) {
+        super(throwable);
+    }
 
-  public NotFoundException() {}
+    public NotFoundException() {}
 }

--- a/src/main/java/com/google/jenkins/plugins/util/RequestCallable.java
+++ b/src/main/java/com/google/jenkins/plugins/util/RequestCallable.java
@@ -27,30 +27,30 @@ import java.util.concurrent.Callable;
  */
 public abstract class RequestCallable<T> implements Callable<T> {
 
-  /** {@inheritDoc} */
-  @Override
-  public abstract T call() throws IOException, ExecutorException;
+    /** {@inheritDoc} */
+    @Override
+    public abstract T call() throws IOException, ExecutorException;
 
-  /** @return whether this request can be retry. */
-  public boolean canRetry() {
-    return true;
-  }
+    /** @return whether this request can be retry. */
+    public boolean canRetry() {
+        return true;
+    }
 
-  /** @return a {@link RequestCallable} that executes a request. */
-  public static <R> RequestCallable<R> from(final AbstractGoogleJsonClientRequest<R> request) {
-    return new RequestCallable<R>() {
+    /** @return a {@link RequestCallable} that executes a request. */
+    public static <R> RequestCallable<R> from(final AbstractGoogleJsonClientRequest<R> request) {
+        return new RequestCallable<R>() {
 
-      /** {@inheritDoc} */
-      @Override
-      public R call() throws IOException {
-        return request.execute();
-      }
+            /** {@inheritDoc} */
+            @Override
+            public R call() throws IOException {
+                return request.execute();
+            }
 
-      /** {@inheritDoc} */
-      @Override
-      public boolean canRetry() {
-        return (request.getMediaHttpUploader() == null);
-      }
-    };
-  }
+            /** {@inheritDoc} */
+            @Override
+            public boolean canRetry() {
+                return (request.getMediaHttpUploader() == null);
+            }
+        };
+    }
 }

--- a/src/main/java/com/google/jenkins/plugins/util/Resolve.java
+++ b/src/main/java/com/google/jenkins/plugins/util/Resolve.java
@@ -29,77 +29,76 @@ import java.util.Map;
  * @author Matt Moore
  */
 public final class Resolve {
-  /**
-   * Replaces Jenkins build variables (e.g. {@code $BUILD_NUMBER}) with sample values, so the result
-   * can be form-validated.
-   *
-   * @param input The unresolved form input string
-   * @return the string with substitutions made for built-in variables.
-   */
-  public static String resolveBuiltin(String input) {
-    return resolveBuiltinWithCustom(checkNotNull(input), Collections.emptyMap());
-  }
+    /**
+     * Replaces Jenkins build variables (e.g. {@code $BUILD_NUMBER}) with sample values, so the result
+     * can be form-validated.
+     *
+     * @param input The unresolved form input string
+     * @return the string with substitutions made for built-in variables.
+     */
+    public static String resolveBuiltin(String input) {
+        return resolveBuiltinWithCustom(checkNotNull(input), Collections.emptyMap());
+    }
 
-  /**
-   * Replaces Jenkins build variables (e.g. {@code $BUILD_NUMBER}) and custom user variables (e.g.
-   * {@code $foo}) with sample values, so the result can be form-validated.
-   *
-   * @param input The unresolved form input string
-   * @param customEnvironment The sample variable values to resolve
-   * @return the string with substitutions made for built-in variables.
-   */
-  public static String resolveBuiltinWithCustom(
-      String input, Map<String, String> customEnvironment) {
-    checkNotNull(input);
-    checkNotNull(customEnvironment);
+    /**
+     * Replaces Jenkins build variables (e.g. {@code $BUILD_NUMBER}) and custom user variables (e.g.
+     * {@code $foo}) with sample values, so the result can be form-validated.
+     *
+     * @param input The unresolved form input string
+     * @param customEnvironment The sample variable values to resolve
+     * @return the string with substitutions made for built-in variables.
+     */
+    public static String resolveBuiltinWithCustom(String input, Map<String, String> customEnvironment) {
+        checkNotNull(input);
+        checkNotNull(customEnvironment);
 
-    // Combine customEnvironment and sampleEnvironment into a new map.
-    Map<String, String> combinedEnvironment = new HashMap<>();
-    combinedEnvironment.putAll(defaultValues);
-    combinedEnvironment.putAll(customEnvironment); // allow overriding defaults
+        // Combine customEnvironment and sampleEnvironment into a new map.
+        Map<String, String> combinedEnvironment = new HashMap<>();
+        combinedEnvironment.putAll(defaultValues);
+        combinedEnvironment.putAll(customEnvironment); // allow overriding defaults
 
-    return resolveCustom(input, combinedEnvironment);
-  }
+        return resolveCustom(input, combinedEnvironment);
+    }
 
-  /**
-   * Replaces a user's custom Jenkins variables (e.g. {@code $foo}) with provided sample values, so
-   * the result can be form-validated.
-   *
-   * @param input The unresolved form input string
-   * @param customEnvironment The sample variable values to resolve
-   * @return the string with substitutions made for variables.
-   */
-  public static String resolveCustom(String input, Map<String, String> customEnvironment) {
-    checkNotNull(input);
-    checkNotNull(customEnvironment);
+    /**
+     * Replaces a user's custom Jenkins variables (e.g. {@code $foo}) with provided sample values, so
+     * the result can be form-validated.
+     *
+     * @param input The unresolved form input string
+     * @param customEnvironment The sample variable values to resolve
+     * @return the string with substitutions made for variables.
+     */
+    public static String resolveCustom(String input, Map<String, String> customEnvironment) {
+        checkNotNull(input);
+        checkNotNull(customEnvironment);
 
-    return Util.replaceMacro(input, customEnvironment);
-  }
+        return Util.replaceMacro(input, customEnvironment);
+    }
 
-  private static Map<String, String> defaultValues = new HashMap<>();
+    private static Map<String, String> defaultValues = new HashMap<>();
 
-  // See: http://wiki.jenkins-ci.org/display/JENKINS/Building+a+software+project
-  static {
-    defaultValues.put("BUILD_NUMBER", "42");
-    defaultValues.put("BUILD_ID", "2005-08-22_23-59-59");
-    defaultValues.put("BUILD_URL", "http://buildserver/jenkins/job/MyJobName/666/");
-    defaultValues.put("NODE_NAME", "master");
-    defaultValues.put("JOB_NAME", "hello world");
-    defaultValues.put("BUILD_TAG", "jenkins-job name-42");
-    defaultValues.put("JENKINS_URL", "https://build.mydomain.org/");
-    defaultValues.put("EXECUTOR_NUMBER", "3");
-    defaultValues.put("JAVA_HOME", "/usr/bin/");
-    defaultValues.put("WORKSPACE", "/tmp/jenkins/");
-    defaultValues.put("SVN_REVISION", "r1234");
-    defaultValues.put("CVS_BRANCH", "TODO");
-    defaultValues.put("GIT_COMMIT", "a48b5b3273a1");
-    defaultValues.put("GIT_BRANCH", "origin/master");
+    // See: http://wiki.jenkins-ci.org/display/JENKINS/Building+a+software+project
+    static {
+        defaultValues.put("BUILD_NUMBER", "42");
+        defaultValues.put("BUILD_ID", "2005-08-22_23-59-59");
+        defaultValues.put("BUILD_URL", "http://buildserver/jenkins/job/MyJobName/666/");
+        defaultValues.put("NODE_NAME", "master");
+        defaultValues.put("JOB_NAME", "hello world");
+        defaultValues.put("BUILD_TAG", "jenkins-job name-42");
+        defaultValues.put("JENKINS_URL", "https://build.mydomain.org/");
+        defaultValues.put("EXECUTOR_NUMBER", "3");
+        defaultValues.put("JAVA_HOME", "/usr/bin/");
+        defaultValues.put("WORKSPACE", "/tmp/jenkins/");
+        defaultValues.put("SVN_REVISION", "r1234");
+        defaultValues.put("CVS_BRANCH", "TODO");
+        defaultValues.put("GIT_COMMIT", "a48b5b3273a1");
+        defaultValues.put("GIT_BRANCH", "origin/master");
 
-    defaultValues = Collections.unmodifiableMap(defaultValues);
-  }
+        defaultValues = Collections.unmodifiableMap(defaultValues);
+    }
 
-  /** Not intended for instantiation. */
-  private Resolve() {
-    throw new UnsupportedOperationException("Not intended for instantiation");
-  }
+    /** Not intended for instantiation. */
+    private Resolve() {
+        throw new UnsupportedOperationException("Not intended for instantiation");
+    }
 }

--- a/src/test/java/com/google/jenkins/plugins/CredentialsOAuthTestSuite.java
+++ b/src/test/java/com/google/jenkins/plugins/CredentialsOAuthTestSuite.java
@@ -29,14 +29,14 @@ import org.junit.runners.Suite;
 /** Defines the full test suite involving OAuth credentials. */
 @RunWith(Suite.class)
 @Suite.SuiteClasses(
-    value = {
-      ConfigurationAsCodeTest.class,
-      GoogleOAuth2ScopeSpecificationTest.class,
-      GoogleRobotCredentialsTest.class,
-      GoogleRobotMetadataCredentialsTest.class,
-      GoogleRobotPrivateKeyCredentialsTest.class,
-      JsonServiceAccountConfigTest.class,
-      P12ServiceAccountConfigTest.class,
-      RemotableGoogleCredentialsTest.class
-    })
+        value = {
+            ConfigurationAsCodeTest.class,
+            GoogleOAuth2ScopeSpecificationTest.class,
+            GoogleRobotCredentialsTest.class,
+            GoogleRobotMetadataCredentialsTest.class,
+            GoogleRobotPrivateKeyCredentialsTest.class,
+            JsonServiceAccountConfigTest.class,
+            P12ServiceAccountConfigTest.class,
+            RemotableGoogleCredentialsTest.class
+        })
 public class CredentialsOAuthTestSuite {}

--- a/src/test/java/com/google/jenkins/plugins/UtilTestSuite.java
+++ b/src/test/java/com/google/jenkins/plugins/UtilTestSuite.java
@@ -26,11 +26,11 @@ import org.junit.runners.Suite;
 /** Defines the full test suite for utility classes. */
 @RunWith(Suite.class)
 @Suite.SuiteClasses(
-    value = {
-      ExecutorTest.class,
-      MetadataReaderTest.class,
-      MockExecutorTest.class,
-      NameValuePairTest.class,
-      ResolveTest.class
-    })
+        value = {
+            ExecutorTest.class,
+            MetadataReaderTest.class,
+            MockExecutorTest.class,
+            NameValuePairTest.class,
+            ResolveTest.class
+        })
 public class UtilTestSuite {}

--- a/src/test/java/com/google/jenkins/plugins/credentials/oauth/ConfigurationAsCodeTest.java
+++ b/src/test/java/com/google/jenkins/plugins/credentials/oauth/ConfigurationAsCodeTest.java
@@ -34,55 +34,53 @@ import org.junit.Test;
 /** Tests that the credentials are correctly processed by the Configuration as Code plugin. */
 public class ConfigurationAsCodeTest {
 
-  @Rule public JenkinsConfiguredWithCodeRule r = new JenkinsConfiguredWithCodeRule();
+    @Rule
+    public JenkinsConfiguredWithCodeRule r = new JenkinsConfiguredWithCodeRule();
 
-  @Test
-  @ConfiguredWithCode("json-service-account-config.yml")
-  public void supportsConfigurationWithJsonServiceAccountConfig() throws IOException {
-    List<GoogleRobotPrivateKeyCredentials> credentialsList =
-        CredentialsProvider.lookupCredentials(GoogleRobotPrivateKeyCredentials.class);
-    assertNotNull(credentialsList);
-    assertEquals("No credentials created", 1, credentialsList.size());
-    GoogleRobotPrivateKeyCredentials credentials = credentialsList.get(0);
-    assertNotNull(credentials);
-    JsonServiceAccountConfig config =
-        (JsonServiceAccountConfig) credentials.getServiceAccountConfig();
-    assertNotNull(config);
-    assertNull(config.getFilename());
-    assertNull(config.getJsonKeyFile());
-    assertNull(config.getJsonKeyFileUpload());
-    assertNull(config.getPrivateKey()); // Because private_key is not valid.
-    SecretBytes bytes = config.getSecretJsonKey();
-    assertEquals("test-account@test-project.iam.gserviceaccount.com", config.getAccountId());
-    String actualBytes = new String(bytes.getPlainData(), StandardCharsets.UTF_8);
-    String expectedBytes =
-        IOUtils.toString(
-            this.getClass().getResourceAsStream("test-key.json"), StandardCharsets.UTF_8);
-    assertEquals("Failed to configure secretJsonKey correctly.", expectedBytes, actualBytes);
-  }
+    @Test
+    @ConfiguredWithCode("json-service-account-config.yml")
+    public void supportsConfigurationWithJsonServiceAccountConfig() throws IOException {
+        List<GoogleRobotPrivateKeyCredentials> credentialsList =
+                CredentialsProvider.lookupCredentials(GoogleRobotPrivateKeyCredentials.class);
+        assertNotNull(credentialsList);
+        assertEquals("No credentials created", 1, credentialsList.size());
+        GoogleRobotPrivateKeyCredentials credentials = credentialsList.get(0);
+        assertNotNull(credentials);
+        JsonServiceAccountConfig config = (JsonServiceAccountConfig) credentials.getServiceAccountConfig();
+        assertNotNull(config);
+        assertNull(config.getFilename());
+        assertNull(config.getJsonKeyFile());
+        assertNull(config.getJsonKeyFileUpload());
+        assertNull(config.getPrivateKey()); // Because private_key is not valid.
+        SecretBytes bytes = config.getSecretJsonKey();
+        assertEquals("test-account@test-project.iam.gserviceaccount.com", config.getAccountId());
+        String actualBytes = new String(bytes.getPlainData(), StandardCharsets.UTF_8);
+        String expectedBytes =
+                IOUtils.toString(this.getClass().getResourceAsStream("test-key.json"), StandardCharsets.UTF_8);
+        assertEquals("Failed to configure secretJsonKey correctly.", expectedBytes, actualBytes);
+    }
 
-  @Test
-  @ConfiguredWithCode("p12-service-account-config.yml")
-  public void supportsConfigurationWithP12ServiceAccountConfig() {
-    List<GoogleRobotPrivateKeyCredentials> credentialsList =
-        CredentialsProvider.lookupCredentials(GoogleRobotPrivateKeyCredentials.class);
-    assertNotNull(credentialsList);
-    assertEquals("No credentials created", 1, credentialsList.size());
-    GoogleRobotPrivateKeyCredentials credentials = credentialsList.get(0);
-    assertNotNull(credentials);
-    P12ServiceAccountConfig config =
-        (P12ServiceAccountConfig) credentials.getServiceAccountConfig();
-    assertNotNull(config);
-    assertNull(config.getFilename());
-    assertNull(config.getP12KeyFile());
-    assertNull(config.getP12KeyFileUpload());
-    // Because the bytes do not form a valid p12 key file.
-    assertNull(config.getPrivateKey());
-    assertEquals("test-account@test-project.iam.gserviceaccount.com", config.getEmailAddress());
-    assertEquals(config.getEmailAddress(), config.getAccountId());
-    SecretBytes bytes = config.getSecretP12Key();
-    String actualBytes = new String(bytes.getPlainData(), StandardCharsets.UTF_8);
-    String expectedBytes = "test-p12-key";
-    assertEquals("Failed to configure secretP12Key correctly", expectedBytes, actualBytes);
-  }
+    @Test
+    @ConfiguredWithCode("p12-service-account-config.yml")
+    public void supportsConfigurationWithP12ServiceAccountConfig() {
+        List<GoogleRobotPrivateKeyCredentials> credentialsList =
+                CredentialsProvider.lookupCredentials(GoogleRobotPrivateKeyCredentials.class);
+        assertNotNull(credentialsList);
+        assertEquals("No credentials created", 1, credentialsList.size());
+        GoogleRobotPrivateKeyCredentials credentials = credentialsList.get(0);
+        assertNotNull(credentials);
+        P12ServiceAccountConfig config = (P12ServiceAccountConfig) credentials.getServiceAccountConfig();
+        assertNotNull(config);
+        assertNull(config.getFilename());
+        assertNull(config.getP12KeyFile());
+        assertNull(config.getP12KeyFileUpload());
+        // Because the bytes do not form a valid p12 key file.
+        assertNull(config.getPrivateKey());
+        assertEquals("test-account@test-project.iam.gserviceaccount.com", config.getEmailAddress());
+        assertEquals(config.getEmailAddress(), config.getAccountId());
+        SecretBytes bytes = config.getSecretP12Key();
+        String actualBytes = new String(bytes.getPlainData(), StandardCharsets.UTF_8);
+        String expectedBytes = "test-p12-key";
+        assertEquals("Failed to configure secretP12Key correctly", expectedBytes, actualBytes);
+    }
 }

--- a/src/test/java/com/google/jenkins/plugins/credentials/oauth/GoogleOAuth2ScopeSpecificationTest.java
+++ b/src/test/java/com/google/jenkins/plugins/credentials/oauth/GoogleOAuth2ScopeSpecificationTest.java
@@ -31,67 +31,65 @@ import org.mockito.MockitoAnnotations;
 
 /** Tests for {@link GoogleOAuth2ScopeSpecification}. */
 public class GoogleOAuth2ScopeSpecificationTest {
-  // Allow for testing using JUnit4, instead of JUnit3.
-  @Rule public JenkinsRule jenkins = new JenkinsRule();
+    // Allow for testing using JUnit4, instead of JUnit3.
+    @Rule
+    public JenkinsRule jenkins = new JenkinsRule();
 
-  @Before
-  public void setUp() throws Exception {
-    MockitoAnnotations.initMocks(this);
-  }
+    @Before
+    public void setUp() throws Exception {
+        MockitoAnnotations.initMocks(this);
+    }
 
-  @Test
-  @WithoutJenkins
-  public void testBasics() throws Exception {
-    GoogleOAuth2ScopeSpecification spec = new GoogleOAuth2ScopeSpecification(GOOD_SCOPES);
+    @Test
+    @WithoutJenkins
+    public void testBasics() throws Exception {
+        GoogleOAuth2ScopeSpecification spec = new GoogleOAuth2ScopeSpecification(GOOD_SCOPES);
 
-    assertThat(spec.getSpecifiedScopes(), hasItems(GOOD_SCOPE1, GOOD_SCOPE2));
-  }
+        assertThat(spec.getSpecifiedScopes(), hasItems(GOOD_SCOPE1, GOOD_SCOPE2));
+    }
 
-  @Test
-  public void testUnknownRequirement() throws Exception {
-    GoogleOAuth2ScopeSpecification spec = new GoogleOAuth2ScopeSpecification(GOOD_SCOPES);
+    @Test
+    public void testUnknownRequirement() throws Exception {
+        GoogleOAuth2ScopeSpecification spec = new GoogleOAuth2ScopeSpecification(GOOD_SCOPES);
 
-    OAuth2ScopeRequirement requirement =
-        new OAuth2ScopeRequirement() {
-          @Override
-          public Collection<String> getScopes() {
-            return GOOD_SCOPES;
-          }
+        OAuth2ScopeRequirement requirement = new OAuth2ScopeRequirement() {
+            @Override
+            public Collection<String> getScopes() {
+                return GOOD_SCOPES;
+            }
         };
 
-    // Verify that even with the right scopes the type kind excludes
-    // the specification from matching this requirement
-    assertEquals(Result.UNKNOWN, spec.test(requirement));
-  }
+        // Verify that even with the right scopes the type kind excludes
+        // the specification from matching this requirement
+        assertEquals(Result.UNKNOWN, spec.test(requirement));
+    }
 
-  @Test
-  public void testKnownRequirements() throws Exception {
-    GoogleOAuth2ScopeSpecification spec = new GoogleOAuth2ScopeSpecification(GOOD_SCOPES);
+    @Test
+    public void testKnownRequirements() throws Exception {
+        GoogleOAuth2ScopeSpecification spec = new GoogleOAuth2ScopeSpecification(GOOD_SCOPES);
 
-    GoogleOAuth2ScopeRequirement goodReq =
-        new GoogleOAuth2ScopeRequirement() {
-          @Override
-          public Collection<String> getScopes() {
-            return GOOD_SCOPES;
-          }
+        GoogleOAuth2ScopeRequirement goodReq = new GoogleOAuth2ScopeRequirement() {
+            @Override
+            public Collection<String> getScopes() {
+                return GOOD_SCOPES;
+            }
         };
-    GoogleOAuth2ScopeRequirement badReq =
-        new GoogleOAuth2ScopeRequirement() {
-          @Override
-          public Collection<String> getScopes() {
-            return BAD_SCOPES;
-          }
+        GoogleOAuth2ScopeRequirement badReq = new GoogleOAuth2ScopeRequirement() {
+            @Override
+            public Collection<String> getScopes() {
+                return BAD_SCOPES;
+            }
         };
 
-    // Verify that with the right type of requirement that
-    // good scopes match POSITIVEly and bad scopes match NEGATIVEly
-    assertEquals(Result.POSITIVE, spec.test(goodReq));
-    assertEquals(Result.NEGATIVE, spec.test(badReq));
-  }
+        // Verify that with the right type of requirement that
+        // good scopes match POSITIVEly and bad scopes match NEGATIVEly
+        assertEquals(Result.POSITIVE, spec.test(goodReq));
+        assertEquals(Result.NEGATIVE, spec.test(badReq));
+    }
 
-  private static String GOOD_SCOPE1 = "foo";
-  private static String GOOD_SCOPE2 = "baz";
-  private static String BAD_SCOPE = "bar";
-  private static Collection<String> GOOD_SCOPES = ImmutableList.of(GOOD_SCOPE1, GOOD_SCOPE2);
-  private static Collection<String> BAD_SCOPES = ImmutableList.of(GOOD_SCOPE1, BAD_SCOPE);
+    private static String GOOD_SCOPE1 = "foo";
+    private static String GOOD_SCOPE2 = "baz";
+    private static String BAD_SCOPE = "bar";
+    private static Collection<String> GOOD_SCOPES = ImmutableList.of(GOOD_SCOPE1, GOOD_SCOPE2);
+    private static Collection<String> BAD_SCOPES = ImmutableList.of(GOOD_SCOPE1, BAD_SCOPE);
 }

--- a/src/test/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotCredentialsTest.java
+++ b/src/test/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotCredentialsTest.java
@@ -48,189 +48,187 @@ import org.mockito.MockitoAnnotations;
 /** Tests for {@link GoogleRobotCredentials}. */
 public class GoogleRobotCredentialsTest {
 
-  // Allow for testing using JUnit4, instead of JUnit3.
-  @Rule public JenkinsRule jenkins = new JenkinsRule();
+    // Allow for testing using JUnit4, instead of JUnit3.
+    @Rule
+    public JenkinsRule jenkins = new JenkinsRule();
 
-  /** */
-  public static class TestRequirement extends TestGoogleOAuth2DomainRequirement {
-    public TestRequirement() {
-      super(FAKE_SCOPE);
-    }
-  }
-
-  /** */
-  public static class NameProvider extends CredentialsNameProvider<GoogleRobotCredentials> {
-    @Override
-    public String getName(GoogleRobotCredentials credentials) {
-      return NAME;
-    }
-  }
-
-  /** */
-  @NameWith(value = NameProvider.class, priority = 100)
-  @RequiresDomain(value = TestRequirement.class)
-  public static class FakeGoogleCredentials extends GoogleRobotCredentials {
-    public FakeGoogleCredentials(String projectId, GoogleCredential credential) {
-      super(CredentialsScope.GLOBAL, "", projectId, new GoogleRobotCredentialsModule());
-
-      this.credential = credential;
-    }
-
-    @Override
-    public GoogleCredential getGoogleCredential(GoogleOAuth2ScopeRequirement requirement)
-        throws GeneralSecurityException {
-      if (credential == null) {
-        throw new GeneralSecurityException("asdf");
-      }
-      return credential;
-    }
-
-    private GoogleCredential credential;
-
-    @Override
-    public String getUsername() {
-      return USERNAME;
+    /** */
+    public static class TestRequirement extends TestGoogleOAuth2DomainRequirement {
+        public TestRequirement() {
+            super(FAKE_SCOPE);
+        }
     }
 
     /** */
-    @Extension
-    public static class DescriptorImpl extends AbstractGoogleRobotCredentialsDescriptor {
-      public DescriptorImpl() {
-        super(FakeGoogleCredentials.class);
-      }
-
-      @Override
-      public String getDisplayName() {
-        return DISPLAY_NAME;
-      }
+    public static class NameProvider extends CredentialsNameProvider<GoogleRobotCredentials> {
+        @Override
+        public String getName(GoogleRobotCredentials credentials) {
+            return NAME;
+        }
     }
-  }
 
-  private GoogleCredential fakeCredential;
+    /** */
+    @NameWith(value = NameProvider.class, priority = 100)
+    @RequiresDomain(value = TestRequirement.class)
+    public static class FakeGoogleCredentials extends GoogleRobotCredentials {
+        public FakeGoogleCredentials(String projectId, GoogleCredential credential) {
+            super(CredentialsScope.GLOBAL, "", projectId, new GoogleRobotCredentialsModule());
 
-  @Before
-  public void setUp() throws Exception {
-    MockitoAnnotations.initMocks(this);
+            this.credential = credential;
+        }
 
-    fakeCredential = new GoogleCredential();
-  }
+        @Override
+        public GoogleCredential getGoogleCredential(GoogleOAuth2ScopeRequirement requirement)
+                throws GeneralSecurityException {
+            if (credential == null) {
+                throw new GeneralSecurityException("asdf");
+            }
+            return credential;
+        }
 
-  @Test
-  @WithoutJenkins
-  public void testGettersNullId() throws Exception {
-    FakeGoogleCredentials credentials = new FakeGoogleCredentials(PROJECT_ID, fakeCredential);
+        private GoogleCredential credential;
 
-    assertEquals(PROJECT_ID, credentials.getProjectId());
-    assertNotNull(credentials.getId());
-    assertSame(fakeCredential, credentials.getGoogleCredential(null));
-    assertTrue(credentials.getDescription().isEmpty());
-  }
+        @Override
+        public String getUsername() {
+            return USERNAME;
+        }
 
-  @Test
-  public void testGetDescriptor() throws Exception {
-    FakeGoogleCredentials credentials = new FakeGoogleCredentials(PROJECT_ID, fakeCredential);
+        /** */
+        @Extension
+        public static class DescriptorImpl extends AbstractGoogleRobotCredentialsDescriptor {
+            public DescriptorImpl() {
+                super(FakeGoogleCredentials.class);
+            }
 
-    Descriptor descriptor = credentials.getDescriptor();
-    assertThat(descriptor, instanceOf(FakeGoogleCredentials.DescriptorImpl.class));
-    assertEquals(DISPLAY_NAME, descriptor.getDisplayName());
-  }
+            @Override
+            public String getDisplayName() {
+                return DISPLAY_NAME;
+            }
+        }
+    }
 
-  @Test
-  @WithoutJenkins
-  public void testGetAccessToken() throws Exception {
-    FakeGoogleCredentials credentials = new FakeGoogleCredentials(PROJECT_ID, fakeCredential);
+    private GoogleCredential fakeCredential;
 
-    fakeCredential.setAccessToken(ACCESS_TOKEN);
-    fakeCredential.setExpiresInSeconds(EXPIRATION_SECONDS);
-    assertEquals(
-        ACCESS_TOKEN, Secret.toString(credentials.getAccessToken(null /* scope requirement */)));
-  }
+    @Before
+    public void setUp() throws Exception {
+        MockitoAnnotations.initMocks(this);
 
-  @Test
-  @WithoutJenkins
-  public void testGetAccessTokenNoCredential() throws Exception {
-    FakeGoogleCredentials credentials =
-        new FakeGoogleCredentials(PROJECT_ID, null /* credential */);
+        fakeCredential = new GoogleCredential();
+    }
 
-    assertNull(credentials.getAccessToken(null));
-  }
+    @Test
+    @WithoutJenkins
+    public void testGettersNullId() throws Exception {
+        FakeGoogleCredentials credentials = new FakeGoogleCredentials(PROJECT_ID, fakeCredential);
 
-  @Test
-  @WithoutJenkins
-  public void testForRemote() throws Exception {
-    FakeGoogleCredentials credentials = new FakeGoogleCredentials(PROJECT_ID, fakeCredential);
+        assertEquals(PROJECT_ID, credentials.getProjectId());
+        assertNotNull(credentials.getId());
+        assertSame(fakeCredential, credentials.getGoogleCredential(null));
+        assertTrue(credentials.getDescription().isEmpty());
+    }
 
-    fakeCredential.setAccessToken(ACCESS_TOKEN);
-    fakeCredential.setExpiresInSeconds(EXPIRATION_SECONDS);
+    @Test
+    public void testGetDescriptor() throws Exception {
+        FakeGoogleCredentials credentials = new FakeGoogleCredentials(PROJECT_ID, fakeCredential);
 
-    GoogleOAuth2ScopeRequirement requirement =
-        new GoogleOAuth2ScopeRequirement() {
-          @Override
-          public Collection<String> getScopes() {
-            return ImmutableList.of();
-          }
+        Descriptor descriptor = credentials.getDescriptor();
+        assertThat(descriptor, instanceOf(FakeGoogleCredentials.DescriptorImpl.class));
+        assertEquals(DISPLAY_NAME, descriptor.getDisplayName());
+    }
+
+    @Test
+    @WithoutJenkins
+    public void testGetAccessToken() throws Exception {
+        FakeGoogleCredentials credentials = new FakeGoogleCredentials(PROJECT_ID, fakeCredential);
+
+        fakeCredential.setAccessToken(ACCESS_TOKEN);
+        fakeCredential.setExpiresInSeconds(EXPIRATION_SECONDS);
+        assertEquals(ACCESS_TOKEN, Secret.toString(credentials.getAccessToken(null /* scope requirement */)));
+    }
+
+    @Test
+    @WithoutJenkins
+    public void testGetAccessTokenNoCredential() throws Exception {
+        FakeGoogleCredentials credentials = new FakeGoogleCredentials(PROJECT_ID, null /* credential */);
+
+        assertNull(credentials.getAccessToken(null));
+    }
+
+    @Test
+    @WithoutJenkins
+    public void testForRemote() throws Exception {
+        FakeGoogleCredentials credentials = new FakeGoogleCredentials(PROJECT_ID, fakeCredential);
+
+        fakeCredential.setAccessToken(ACCESS_TOKEN);
+        fakeCredential.setExpiresInSeconds(EXPIRATION_SECONDS);
+
+        GoogleOAuth2ScopeRequirement requirement = new GoogleOAuth2ScopeRequirement() {
+            @Override
+            public Collection<String> getScopes() {
+                return ImmutableList.of();
+            }
         };
-    GoogleRobotCredentials remotable = credentials.forRemote(requirement);
+        GoogleRobotCredentials remotable = credentials.forRemote(requirement);
 
-    assertEquals(USERNAME, remotable.getUsername());
-    assertEquals(ACCESS_TOKEN, Secret.toString(remotable.getAccessToken(requirement)));
-    assertSame(remotable, remotable.forRemote(requirement));
-  }
-
-  @Test
-  public void testListBoxEmpty() throws Exception {
-    ListBoxModel list = GoogleRobotCredentials.getCredentialsListBox(FakeGoogleCredentials.class);
-
-    assertEquals(0, list.size());
-
-    FakeGoogleCredentials credentials = new FakeGoogleCredentials(PROJECT_ID, fakeCredential);
-    SystemCredentialsProvider.getInstance().getCredentials().add(credentials);
-
-    list = GoogleRobotCredentials.getCredentialsListBox(FakeGoogleCredentials.class);
-
-    assertEquals(1, list.size());
-    for (ListBoxModel.Option option : list) {
-      assertEquals(NAME, option.name);
-      assertEquals(credentials.getId(), option.value);
+        assertEquals(USERNAME, remotable.getUsername());
+        assertEquals(ACCESS_TOKEN, Secret.toString(remotable.getAccessToken(requirement)));
+        assertSame(remotable, remotable.forRemote(requirement));
     }
-  }
 
-  @Test
-  public void testGetById() throws Exception {
-    FakeGoogleCredentials credentials = new FakeGoogleCredentials(PROJECT_ID, fakeCredential);
-    assertNull(GoogleRobotCredentials.getById(credentials.getId()));
+    @Test
+    public void testListBoxEmpty() throws Exception {
+        ListBoxModel list = GoogleRobotCredentials.getCredentialsListBox(FakeGoogleCredentials.class);
 
-    SystemCredentialsProvider.getInstance().getCredentials().add(credentials);
+        assertEquals(0, list.size());
 
-    assertSame(credentials, GoogleRobotCredentials.getById(credentials.getId()));
-    assertNull(GoogleRobotCredentials.getById("not an id"));
-  }
+        FakeGoogleCredentials credentials = new FakeGoogleCredentials(PROJECT_ID, fakeCredential);
+        SystemCredentialsProvider.getInstance().getCredentials().add(credentials);
 
-  @LocalData
-  @Test
-  public void testMigration() {
-    /* LocalData contains an old credential with no id field and the project id my-google-project.
-    On deserialization the id should be filled with the project id.
-    We didn't specify description in credentials.xml and it should be empty
-    */
-    GoogleRobotCredentials credentials = GoogleRobotCredentials.getById(MIGRATION_PROJECT_ID);
-    assertNotNull(credentials);
-    assertTrue(credentials.getDescription().isEmpty());
-  }
+        list = GoogleRobotCredentials.getCredentialsListBox(FakeGoogleCredentials.class);
 
-  @Test
-  public void testMultipleCredentials() {
-    FakeGoogleCredentials credential1 = new FakeGoogleCredentials(PROJECT_ID, null);
-    FakeGoogleCredentials credential2 = new FakeGoogleCredentials(PROJECT_ID, null);
-    assertNotEquals(credential1, credential2);
-  }
+        assertEquals(1, list.size());
+        for (ListBoxModel.Option option : list) {
+            assertEquals(NAME, option.name);
+            assertEquals(credentials.getId(), option.value);
+        }
+    }
 
-  private static final String NAME = "my credential name";
-  private static final String FAKE_SCOPE = "my.fake.scope";
-  private static final String DISPLAY_NAME = "blah";
-  private static final String PROJECT_ID = "foo.com:bar-baz";
-  private static final String MIGRATION_PROJECT_ID = "my-google-project";
-  private static final String USERNAME = "mattomata";
-  private static final String ACCESS_TOKEN = "ThE.ToKeN";
-  private static final long EXPIRATION_SECONDS = 1234;
+    @Test
+    public void testGetById() throws Exception {
+        FakeGoogleCredentials credentials = new FakeGoogleCredentials(PROJECT_ID, fakeCredential);
+        assertNull(GoogleRobotCredentials.getById(credentials.getId()));
+
+        SystemCredentialsProvider.getInstance().getCredentials().add(credentials);
+
+        assertSame(credentials, GoogleRobotCredentials.getById(credentials.getId()));
+        assertNull(GoogleRobotCredentials.getById("not an id"));
+    }
+
+    @LocalData
+    @Test
+    public void testMigration() {
+        /* LocalData contains an old credential with no id field and the project id my-google-project.
+        On deserialization the id should be filled with the project id.
+        We didn't specify description in credentials.xml and it should be empty
+        */
+        GoogleRobotCredentials credentials = GoogleRobotCredentials.getById(MIGRATION_PROJECT_ID);
+        assertNotNull(credentials);
+        assertTrue(credentials.getDescription().isEmpty());
+    }
+
+    @Test
+    public void testMultipleCredentials() {
+        FakeGoogleCredentials credential1 = new FakeGoogleCredentials(PROJECT_ID, null);
+        FakeGoogleCredentials credential2 = new FakeGoogleCredentials(PROJECT_ID, null);
+        assertNotEquals(credential1, credential2);
+    }
+
+    private static final String NAME = "my credential name";
+    private static final String FAKE_SCOPE = "my.fake.scope";
+    private static final String DISPLAY_NAME = "blah";
+    private static final String PROJECT_ID = "foo.com:bar-baz";
+    private static final String MIGRATION_PROJECT_ID = "my-google-project";
+    private static final String USERNAME = "mattomata";
+    private static final String ACCESS_TOKEN = "ThE.ToKeN";
+    private static final long EXPIRATION_SECONDS = 1234;
 }

--- a/src/test/java/com/google/jenkins/plugins/credentials/oauth/JsonServiceAccountConfigTest.java
+++ b/src/test/java/com/google/jenkins/plugins/credentials/oauth/JsonServiceAccountConfigTest.java
@@ -37,125 +37,126 @@ import org.mockito.MockitoAnnotations;
 
 /** Tests for {@link JsonServiceAccountConfig}. */
 public class JsonServiceAccountConfigTest {
-  private static final String SERVICE_ACCOUNT_EMAIL_ADDRESS = "service@account.com";
-  private static PrivateKey privateKey;
-  private static String jsonKeyPath;
-  @Rule public JenkinsRule jenkinsRule = new JenkinsRule();
-  @Mock private FileItem mockFileItem;
+    private static final String SERVICE_ACCOUNT_EMAIL_ADDRESS = "service@account.com";
+    private static PrivateKey privateKey;
+    private static String jsonKeyPath;
 
-  @BeforeClass
-  public static void preparePrivateKey() throws Exception {
-    privateKey = JsonServiceAccountConfigTestUtil.generatePrivateKey();
-    jsonKeyPath =
-        JsonServiceAccountConfigTestUtil.createTempJsonKeyFile(
-            SERVICE_ACCOUNT_EMAIL_ADDRESS, privateKey);
-  }
+    @Rule
+    public JenkinsRule jenkinsRule = new JenkinsRule();
 
-  @Before
-  public void setUp() {
-    MockitoAnnotations.initMocks(this);
-  }
+    @Mock
+    private FileItem mockFileItem;
 
-  @Test
-  public void testCreateJsonKeyTypeWithNewJsonKeyFile() throws Exception {
-    when(mockFileItem.getSize()).thenReturn(1L);
-    when(mockFileItem.getInputStream()).thenReturn(new FileInputStream(jsonKeyPath));
-    when(mockFileItem.getName()).thenReturn(jsonKeyPath);
-    when(mockFileItem.get()).thenReturn(FileUtils.readFileToByteArray(new File(jsonKeyPath)));
-    JsonServiceAccountConfig jsonKeyType = new JsonServiceAccountConfig();
-    jsonKeyType.setJsonKeyFileUpload(mockFileItem);
+    @BeforeClass
+    public static void preparePrivateKey() throws Exception {
+        privateKey = JsonServiceAccountConfigTestUtil.generatePrivateKey();
+        jsonKeyPath = JsonServiceAccountConfigTestUtil.createTempJsonKeyFile(SERVICE_ACCOUNT_EMAIL_ADDRESS, privateKey);
+    }
 
-    assertEquals(SERVICE_ACCOUNT_EMAIL_ADDRESS, jsonKeyType.getAccountId());
-    assertEquals(privateKey, jsonKeyType.getPrivateKey());
-  }
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+    }
 
-  @Test
-  public void testCreateJsonKeyTypeWithNullParameters() {
-    JsonServiceAccountConfig jsonServiceAccountConfig = new JsonServiceAccountConfig();
+    @Test
+    public void testCreateJsonKeyTypeWithNewJsonKeyFile() throws Exception {
+        when(mockFileItem.getSize()).thenReturn(1L);
+        when(mockFileItem.getInputStream()).thenReturn(new FileInputStream(jsonKeyPath));
+        when(mockFileItem.getName()).thenReturn(jsonKeyPath);
+        when(mockFileItem.get()).thenReturn(FileUtils.readFileToByteArray(new File(jsonKeyPath)));
+        JsonServiceAccountConfig jsonKeyType = new JsonServiceAccountConfig();
+        jsonKeyType.setJsonKeyFileUpload(mockFileItem);
 
-    assertNull(jsonServiceAccountConfig.getAccountId());
-    assertNull(jsonServiceAccountConfig.getPrivateKey());
-  }
+        assertEquals(SERVICE_ACCOUNT_EMAIL_ADDRESS, jsonKeyType.getAccountId());
+        assertEquals(privateKey, jsonKeyType.getPrivateKey());
+    }
 
-  @Test
-  public void testCreateJsonKeyTypeWithEmptyJsonKeyFile() throws Exception {
-    when(mockFileItem.getSize()).thenReturn(0L);
-    JsonServiceAccountConfig jsonKeyType = new JsonServiceAccountConfig();
-    jsonKeyType.setJsonKeyFileUpload(mockFileItem);
+    @Test
+    public void testCreateJsonKeyTypeWithNullParameters() {
+        JsonServiceAccountConfig jsonServiceAccountConfig = new JsonServiceAccountConfig();
 
-    assertNull(jsonKeyType.getJsonKeyFile());
-    assertNull(jsonKeyType.getAccountId());
-    assertNull(jsonKeyType.getPrivateKey());
-  }
+        assertNull(jsonServiceAccountConfig.getAccountId());
+        assertNull(jsonServiceAccountConfig.getPrivateKey());
+    }
 
-  @Test
-  public void testCreateJsonKeyTypeWithInvalidJsonKeyFile() throws Exception {
-    byte[] bytes = "invalidJsonKeyFile".getBytes();
-    when(mockFileItem.getSize()).thenReturn((long) bytes.length);
-    when(mockFileItem.getInputStream()).thenReturn(new ByteArrayInputStream(bytes));
-    JsonServiceAccountConfig jsonServiceAccountConfig = new JsonServiceAccountConfig();
-    jsonServiceAccountConfig.setJsonKeyFileUpload(mockFileItem);
+    @Test
+    public void testCreateJsonKeyTypeWithEmptyJsonKeyFile() throws Exception {
+        when(mockFileItem.getSize()).thenReturn(0L);
+        JsonServiceAccountConfig jsonKeyType = new JsonServiceAccountConfig();
+        jsonKeyType.setJsonKeyFileUpload(mockFileItem);
 
-    assertNull(jsonServiceAccountConfig.getAccountId());
-    assertNull(jsonServiceAccountConfig.getPrivateKey());
-  }
+        assertNull(jsonKeyType.getJsonKeyFile());
+        assertNull(jsonKeyType.getAccountId());
+        assertNull(jsonKeyType.getPrivateKey());
+    }
 
-  @Test
-  public void testCreateJsonKeyTypeWithPrevJsonKeyFileForCompatibility() {
-    JsonServiceAccountConfig jsonServiceAccountConfig =
-        new JsonServiceAccountConfig(null, jsonKeyPath);
+    @Test
+    public void testCreateJsonKeyTypeWithInvalidJsonKeyFile() throws Exception {
+        byte[] bytes = "invalidJsonKeyFile".getBytes();
+        when(mockFileItem.getSize()).thenReturn((long) bytes.length);
+        when(mockFileItem.getInputStream()).thenReturn(new ByteArrayInputStream(bytes));
+        JsonServiceAccountConfig jsonServiceAccountConfig = new JsonServiceAccountConfig();
+        jsonServiceAccountConfig.setJsonKeyFileUpload(mockFileItem);
 
-    assertEquals(SERVICE_ACCOUNT_EMAIL_ADDRESS, jsonServiceAccountConfig.getAccountId());
-    assertEquals(privateKey, jsonServiceAccountConfig.getPrivateKey());
-  }
+        assertNull(jsonServiceAccountConfig.getAccountId());
+        assertNull(jsonServiceAccountConfig.getPrivateKey());
+    }
 
-  @Test
-  public void testCreateJsonKeyTypeWithPrevJsonKeyFile() throws Exception {
-    SecretBytes prev = SecretBytes.fromBytes(FileUtils.readFileToByteArray(new File(jsonKeyPath)));
-    JsonServiceAccountConfig jsonServiceAccountConfig = new JsonServiceAccountConfig();
-    jsonServiceAccountConfig.setFilename(jsonKeyPath);
-    jsonServiceAccountConfig.setSecretJsonKey(prev);
+    @Test
+    public void testCreateJsonKeyTypeWithPrevJsonKeyFileForCompatibility() {
+        JsonServiceAccountConfig jsonServiceAccountConfig = new JsonServiceAccountConfig(null, jsonKeyPath);
 
-    assertEquals(SERVICE_ACCOUNT_EMAIL_ADDRESS, jsonServiceAccountConfig.getAccountId());
-    assertEquals(privateKey, jsonServiceAccountConfig.getPrivateKey());
-  }
+        assertEquals(SERVICE_ACCOUNT_EMAIL_ADDRESS, jsonServiceAccountConfig.getAccountId());
+        assertEquals(privateKey, jsonServiceAccountConfig.getPrivateKey());
+    }
 
-  @Test
-  public void testCreateJsonKeyTypeWithEmptyPrevJsonKeyFile() {
-    SecretBytes prev = SecretBytes.fromString("");
-    JsonServiceAccountConfig jsonServiceAccountConfig = new JsonServiceAccountConfig();
-    jsonServiceAccountConfig.setFilename("");
-    jsonServiceAccountConfig.setSecretJsonKey(prev);
+    @Test
+    public void testCreateJsonKeyTypeWithPrevJsonKeyFile() throws Exception {
+        SecretBytes prev = SecretBytes.fromBytes(FileUtils.readFileToByteArray(new File(jsonKeyPath)));
+        JsonServiceAccountConfig jsonServiceAccountConfig = new JsonServiceAccountConfig();
+        jsonServiceAccountConfig.setFilename(jsonKeyPath);
+        jsonServiceAccountConfig.setSecretJsonKey(prev);
 
-    assertNull(jsonServiceAccountConfig.getAccountId());
-    assertNull(jsonServiceAccountConfig.getPrivateKey());
-  }
+        assertEquals(SERVICE_ACCOUNT_EMAIL_ADDRESS, jsonServiceAccountConfig.getAccountId());
+        assertEquals(privateKey, jsonServiceAccountConfig.getPrivateKey());
+    }
 
-  @Test
-  public void testCreateJsonKeyTypeWithInvalidPrevJsonKeyFile() {
-    JsonServiceAccountConfig jsonServiceAccountConfig =
-        new JsonServiceAccountConfig(null, "invalidPrevJsonKeyFile.json");
+    @Test
+    public void testCreateJsonKeyTypeWithEmptyPrevJsonKeyFile() {
+        SecretBytes prev = SecretBytes.fromString("");
+        JsonServiceAccountConfig jsonServiceAccountConfig = new JsonServiceAccountConfig();
+        jsonServiceAccountConfig.setFilename("");
+        jsonServiceAccountConfig.setSecretJsonKey(prev);
 
-    assertNull(jsonServiceAccountConfig.getAccountId());
-    assertNull(jsonServiceAccountConfig.getPrivateKey());
-  }
+        assertNull(jsonServiceAccountConfig.getAccountId());
+        assertNull(jsonServiceAccountConfig.getPrivateKey());
+    }
 
-  @Test
-  public void testSerialization() throws Exception {
-    when(mockFileItem.getSize()).thenReturn(1L);
-    when(mockFileItem.getName()).thenReturn(jsonKeyPath);
-    when(mockFileItem.getInputStream()).thenReturn(new FileInputStream(jsonKeyPath));
-    when(mockFileItem.get()).thenReturn(FileUtils.readFileToByteArray(new File(jsonKeyPath)));
-    JsonServiceAccountConfig jsonServiceAccountConfig = new JsonServiceAccountConfig();
-    jsonServiceAccountConfig.setJsonKeyFileUpload(mockFileItem);
+    @Test
+    public void testCreateJsonKeyTypeWithInvalidPrevJsonKeyFile() {
+        JsonServiceAccountConfig jsonServiceAccountConfig =
+                new JsonServiceAccountConfig(null, "invalidPrevJsonKeyFile.json");
 
-    ByteArrayOutputStream out = new ByteArrayOutputStream();
-    SerializationUtil.serialize(jsonServiceAccountConfig, out);
-    ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
-    JsonServiceAccountConfig deserializedJsonKeyType =
-        SerializationUtil.deserialize(JsonServiceAccountConfig.class, in);
+        assertNull(jsonServiceAccountConfig.getAccountId());
+        assertNull(jsonServiceAccountConfig.getPrivateKey());
+    }
 
-    assertEquals(SERVICE_ACCOUNT_EMAIL_ADDRESS, deserializedJsonKeyType.getAccountId());
-    assertEquals(privateKey, deserializedJsonKeyType.getPrivateKey());
-  }
+    @Test
+    public void testSerialization() throws Exception {
+        when(mockFileItem.getSize()).thenReturn(1L);
+        when(mockFileItem.getName()).thenReturn(jsonKeyPath);
+        when(mockFileItem.getInputStream()).thenReturn(new FileInputStream(jsonKeyPath));
+        when(mockFileItem.get()).thenReturn(FileUtils.readFileToByteArray(new File(jsonKeyPath)));
+        JsonServiceAccountConfig jsonServiceAccountConfig = new JsonServiceAccountConfig();
+        jsonServiceAccountConfig.setJsonKeyFileUpload(mockFileItem);
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        SerializationUtil.serialize(jsonServiceAccountConfig, out);
+        ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
+        JsonServiceAccountConfig deserializedJsonKeyType =
+                SerializationUtil.deserialize(JsonServiceAccountConfig.class, in);
+
+        assertEquals(SERVICE_ACCOUNT_EMAIL_ADDRESS, deserializedJsonKeyType.getAccountId());
+        assertEquals(privateKey, deserializedJsonKeyType.getPrivateKey());
+    }
 }

--- a/src/test/java/com/google/jenkins/plugins/credentials/oauth/JsonServiceAccountConfigTestUtil.java
+++ b/src/test/java/com/google/jenkins/plugins/credentials/oauth/JsonServiceAccountConfigTestUtil.java
@@ -34,57 +34,54 @@ import org.bouncycastle.openssl.PEMWriter;
 
 /** Util class for {@link JsonServiceAccountConfigTest}. */
 public class JsonServiceAccountConfigTestUtil {
-  private static File tempFolder;
+    private static File tempFolder;
 
-  public static PrivateKey generatePrivateKey()
-      throws NoSuchProviderException, NoSuchAlgorithmException {
-    Security.addProvider(new BouncyCastleProvider());
-    final KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("RSA", "BC");
-    keyPairGenerator.initialize(1024);
-    final KeyPair keyPair = keyPairGenerator.generateKeyPair();
-    return keyPair.getPrivate();
-  }
-
-  public static String createTempJsonKeyFile(String clientEmail, PrivateKey privateKey)
-      throws IOException {
-    final File tempJsonKey = File.createTempFile("temp-key", ".json", getTempFolder());
-    JsonGenerator jsonGenerator = null;
-    try {
-      jsonGenerator =
-          new JacksonFactory()
-              .createJsonGenerator(new FileOutputStream(tempJsonKey), Charset.forName("UTF-8"));
-      jsonGenerator.enablePrettyPrint();
-      jsonGenerator.serialize(createJsonKey(clientEmail, privateKey));
-    } finally {
-      if (jsonGenerator != null) {
-        jsonGenerator.close();
-      }
+    public static PrivateKey generatePrivateKey() throws NoSuchProviderException, NoSuchAlgorithmException {
+        Security.addProvider(new BouncyCastleProvider());
+        final KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("RSA", "BC");
+        keyPairGenerator.initialize(1024);
+        final KeyPair keyPair = keyPairGenerator.generateKeyPair();
+        return keyPair.getPrivate();
     }
-    return tempJsonKey.getAbsolutePath();
-  }
 
-  private static File getTempFolder() throws IOException {
-    if (tempFolder == null) {
-      tempFolder = Files.createTempDirectory("temp" + Long.toString(System.nanoTime())).toFile();
-      tempFolder.deleteOnExit();
+    public static String createTempJsonKeyFile(String clientEmail, PrivateKey privateKey) throws IOException {
+        final File tempJsonKey = File.createTempFile("temp-key", ".json", getTempFolder());
+        JsonGenerator jsonGenerator = null;
+        try {
+            jsonGenerator = new JacksonFactory()
+                    .createJsonGenerator(new FileOutputStream(tempJsonKey), Charset.forName("UTF-8"));
+            jsonGenerator.enablePrettyPrint();
+            jsonGenerator.serialize(createJsonKey(clientEmail, privateKey));
+        } finally {
+            if (jsonGenerator != null) {
+                jsonGenerator.close();
+            }
+        }
+        return tempJsonKey.getAbsolutePath();
     }
-    return tempFolder;
-  }
 
-  private static JsonKey createJsonKey(String clientEmail, PrivateKey privateKey)
-      throws IOException {
-    final JsonKey jsonKey = new JsonKey();
-    jsonKey.setClientEmail(clientEmail);
-    jsonKey.setPrivateKey(getInPemFormat(privateKey));
-    return jsonKey;
-  }
+    private static File getTempFolder() throws IOException {
+        if (tempFolder == null) {
+            tempFolder = Files.createTempDirectory("temp" + Long.toString(System.nanoTime()))
+                    .toFile();
+            tempFolder.deleteOnExit();
+        }
+        return tempFolder;
+    }
 
-  private static String getInPemFormat(PrivateKey privateKey) throws IOException {
-    final StringWriter stringWriter = new StringWriter();
-    final PEMWriter pemWriter = new PEMWriter(stringWriter);
-    pemWriter.writeObject(privateKey);
-    pemWriter.flush();
-    pemWriter.close();
-    return stringWriter.toString();
-  }
+    private static JsonKey createJsonKey(String clientEmail, PrivateKey privateKey) throws IOException {
+        final JsonKey jsonKey = new JsonKey();
+        jsonKey.setClientEmail(clientEmail);
+        jsonKey.setPrivateKey(getInPemFormat(privateKey));
+        return jsonKey;
+    }
+
+    private static String getInPemFormat(PrivateKey privateKey) throws IOException {
+        final StringWriter stringWriter = new StringWriter();
+        final PEMWriter pemWriter = new PEMWriter(stringWriter);
+        pemWriter.writeObject(privateKey);
+        pemWriter.flush();
+        pemWriter.close();
+        return stringWriter.toString();
+    }
 }

--- a/src/test/java/com/google/jenkins/plugins/credentials/oauth/LegacyJsonServiceAccountConfigUtil.java
+++ b/src/test/java/com/google/jenkins/plugins/credentials/oauth/LegacyJsonServiceAccountConfigUtil.java
@@ -28,89 +28,86 @@ import java.nio.file.Files;
  * .GoogleRobotPrivateKeyCredentials}.
  */
 public class LegacyJsonServiceAccountConfigUtil {
-  private static File tempFolder;
+    private static File tempFolder;
 
-  public static String createTempLegacyJsonKeyFile(String clientEmail) throws IOException {
-    final File tempLegacyJsonKey = File.createTempFile("temp-legacykey", ".json", getTempFolder());
-    final JsonGenerator jsonGenerator =
-        new JacksonFactory()
-            .createJsonGenerator(new FileOutputStream(tempLegacyJsonKey), Charset.forName("UTF-8"));
-    jsonGenerator.enablePrettyPrint();
-    jsonGenerator.serialize(createLegacyJsonKey(clientEmail));
-    jsonGenerator.close();
-    return tempLegacyJsonKey.getAbsolutePath();
-  }
-
-  public static String createTempLegacyJsonKeyFileWithMissingWebObject() throws IOException {
-    final File tempLegacyJsonKey = File.createTempFile("temp-legacykey", ".json", getTempFolder());
-    final JsonGenerator jsonGenerator =
-        new JacksonFactory()
-            .createJsonGenerator(new FileOutputStream(tempLegacyJsonKey), Charset.forName("UTF-8"));
-    jsonGenerator.enablePrettyPrint();
-    jsonGenerator.serialize(createLegacyJsonKeyWithMissingWebObject());
-    jsonGenerator.close();
-    return tempLegacyJsonKey.getAbsolutePath();
-  }
-
-  public static String createTempLegacyJsonKeyFileWithMissingClientEmail() throws IOException {
-    final File tempLegacyJsonKey = File.createTempFile("temp-legacykey", ".json", getTempFolder());
-    JsonGenerator jsonGenerator = null;
-    try {
-      jsonGenerator =
-          new JacksonFactory()
-              .createJsonGenerator(
-                  new FileOutputStream(tempLegacyJsonKey), Charset.forName("UTF-8"));
-      jsonGenerator.enablePrettyPrint();
-      jsonGenerator.serialize(createLegacyJsonKeyWithMissingClientEmail());
-    } finally {
-      if (jsonGenerator != null) {
+    public static String createTempLegacyJsonKeyFile(String clientEmail) throws IOException {
+        final File tempLegacyJsonKey = File.createTempFile("temp-legacykey", ".json", getTempFolder());
+        final JsonGenerator jsonGenerator = new JacksonFactory()
+                .createJsonGenerator(new FileOutputStream(tempLegacyJsonKey), Charset.forName("UTF-8"));
+        jsonGenerator.enablePrettyPrint();
+        jsonGenerator.serialize(createLegacyJsonKey(clientEmail));
         jsonGenerator.close();
-      }
+        return tempLegacyJsonKey.getAbsolutePath();
     }
-    return tempLegacyJsonKey.getAbsolutePath();
-  }
 
-  public static String createTempInvalidLegacyJsonKeyFile() throws IOException {
-    final File tempLegacyJsonKey = File.createTempFile("temp-legacykey", ".json", getTempFolder());
-    FileOutputStream out = null;
-    try {
-      out = new FileOutputStream(tempLegacyJsonKey);
-      out.write("InvalidLegacyJsonKeyFile".getBytes());
-      out.flush();
-    } finally {
-      if (out != null) {
-        out.close();
-      }
+    public static String createTempLegacyJsonKeyFileWithMissingWebObject() throws IOException {
+        final File tempLegacyJsonKey = File.createTempFile("temp-legacykey", ".json", getTempFolder());
+        final JsonGenerator jsonGenerator = new JacksonFactory()
+                .createJsonGenerator(new FileOutputStream(tempLegacyJsonKey), Charset.forName("UTF-8"));
+        jsonGenerator.enablePrettyPrint();
+        jsonGenerator.serialize(createLegacyJsonKeyWithMissingWebObject());
+        jsonGenerator.close();
+        return tempLegacyJsonKey.getAbsolutePath();
     }
-    return tempLegacyJsonKey.getAbsolutePath();
-  }
 
-  private static File getTempFolder() throws IOException {
-    if (tempFolder == null) {
-      tempFolder = Files.createTempDirectory("temp" + Long.toString(System.nanoTime())).toFile();
-      tempFolder.deleteOnExit();
+    public static String createTempLegacyJsonKeyFileWithMissingClientEmail() throws IOException {
+        final File tempLegacyJsonKey = File.createTempFile("temp-legacykey", ".json", getTempFolder());
+        JsonGenerator jsonGenerator = null;
+        try {
+            jsonGenerator = new JacksonFactory()
+                    .createJsonGenerator(new FileOutputStream(tempLegacyJsonKey), Charset.forName("UTF-8"));
+            jsonGenerator.enablePrettyPrint();
+            jsonGenerator.serialize(createLegacyJsonKeyWithMissingClientEmail());
+        } finally {
+            if (jsonGenerator != null) {
+                jsonGenerator.close();
+            }
+        }
+        return tempLegacyJsonKey.getAbsolutePath();
     }
-    return tempFolder;
-  }
 
-  @SuppressWarnings("deprecation")
-  private static LegacyJsonKey createLegacyJsonKey(String clientEmail) throws IOException {
-    final LegacyJsonKey legacyJsonKey = new LegacyJsonKey();
-    LegacyJsonKey.Details web = new LegacyJsonKey.Details();
-    web.setClientEmail(clientEmail);
-    legacyJsonKey.setWeb(web);
-    return legacyJsonKey;
-  }
+    public static String createTempInvalidLegacyJsonKeyFile() throws IOException {
+        final File tempLegacyJsonKey = File.createTempFile("temp-legacykey", ".json", getTempFolder());
+        FileOutputStream out = null;
+        try {
+            out = new FileOutputStream(tempLegacyJsonKey);
+            out.write("InvalidLegacyJsonKeyFile".getBytes());
+            out.flush();
+        } finally {
+            if (out != null) {
+                out.close();
+            }
+        }
+        return tempLegacyJsonKey.getAbsolutePath();
+    }
 
-  @SuppressWarnings("deprecation")
-  private static LegacyJsonKey createLegacyJsonKeyWithMissingWebObject() throws IOException {
-    return new LegacyJsonKey();
-  }
+    private static File getTempFolder() throws IOException {
+        if (tempFolder == null) {
+            tempFolder = Files.createTempDirectory("temp" + Long.toString(System.nanoTime()))
+                    .toFile();
+            tempFolder.deleteOnExit();
+        }
+        return tempFolder;
+    }
 
-  @SuppressWarnings("deprecation")
-  private static LegacyJsonKey createLegacyJsonKeyWithMissingClientEmail() throws IOException {
-    final LegacyJsonKey legacyJsonKey = new LegacyJsonKey();
-    legacyJsonKey.setWeb(new LegacyJsonKey.Details());
-    return legacyJsonKey;
-  }
+    @SuppressWarnings("deprecation")
+    private static LegacyJsonKey createLegacyJsonKey(String clientEmail) throws IOException {
+        final LegacyJsonKey legacyJsonKey = new LegacyJsonKey();
+        LegacyJsonKey.Details web = new LegacyJsonKey.Details();
+        web.setClientEmail(clientEmail);
+        legacyJsonKey.setWeb(web);
+        return legacyJsonKey;
+    }
+
+    @SuppressWarnings("deprecation")
+    private static LegacyJsonKey createLegacyJsonKeyWithMissingWebObject() throws IOException {
+        return new LegacyJsonKey();
+    }
+
+    @SuppressWarnings("deprecation")
+    private static LegacyJsonKey createLegacyJsonKeyWithMissingClientEmail() throws IOException {
+        final LegacyJsonKey legacyJsonKey = new LegacyJsonKey();
+        legacyJsonKey.setWeb(new LegacyJsonKey.Details());
+        return legacyJsonKey;
+    }
 }

--- a/src/test/java/com/google/jenkins/plugins/credentials/oauth/P12ServiceAccountConfigTest.java
+++ b/src/test/java/com/google/jenkins/plugins/credentials/oauth/P12ServiceAccountConfigTest.java
@@ -37,143 +37,139 @@ import org.mockito.MockitoAnnotations;
 
 /** Tests for {@link P12ServiceAccountConfig}. */
 public class P12ServiceAccountConfigTest {
-  private static final String SERVICE_ACCOUNT_EMAIL_ADDRESS = "service@account.com";
-  private static KeyPair keyPair;
-  private static String p12KeyPath;
-  @Rule public JenkinsRule jenkinsRule = new JenkinsRule();
-  @Mock private FileItem mockFileItem;
+    private static final String SERVICE_ACCOUNT_EMAIL_ADDRESS = "service@account.com";
+    private static KeyPair keyPair;
+    private static String p12KeyPath;
 
-  @BeforeClass
-  public static void preparePrivateKey() throws Exception {
-    keyPair = P12ServiceAccountConfigTestUtil.generateKeyPair();
-    p12KeyPath = P12ServiceAccountConfigTestUtil.createTempP12KeyFile(keyPair);
-  }
+    @Rule
+    public JenkinsRule jenkinsRule = new JenkinsRule();
 
-  @Before
-  public void setUp() throws Exception {
-    MockitoAnnotations.initMocks(this);
-  }
+    @Mock
+    private FileItem mockFileItem;
 
-  @Test
-  public void testCreateWithNewP12KeyFile() throws Exception {
-    when(mockFileItem.getSize()).thenReturn(1L);
-    when(mockFileItem.getName()).thenReturn(p12KeyPath);
-    when(mockFileItem.get()).thenReturn(FileUtils.readFileToByteArray(new File(p12KeyPath)));
-    P12ServiceAccountConfig p12ServiceAccountConfig =
-        new P12ServiceAccountConfig(SERVICE_ACCOUNT_EMAIL_ADDRESS);
-    p12ServiceAccountConfig.setP12KeyFileUpload(mockFileItem);
+    @BeforeClass
+    public static void preparePrivateKey() throws Exception {
+        keyPair = P12ServiceAccountConfigTestUtil.generateKeyPair();
+        p12KeyPath = P12ServiceAccountConfigTestUtil.createTempP12KeyFile(keyPair);
+    }
 
-    assertEquals(SERVICE_ACCOUNT_EMAIL_ADDRESS, p12ServiceAccountConfig.getAccountId());
-    assertEquals(keyPair.getPrivate(), p12ServiceAccountConfig.getPrivateKey());
-  }
+    @Before
+    public void setUp() throws Exception {
+        MockitoAnnotations.initMocks(this);
+    }
 
-  @Test
-  public void testCreateWithNullAccountId() throws Exception {
-    SecretBytes prev = SecretBytes.fromBytes(FileUtils.readFileToByteArray(new File(p12KeyPath)));
-    P12ServiceAccountConfig p12ServiceAccountConfig = new P12ServiceAccountConfig(null);
-    p12ServiceAccountConfig.setFilename(p12KeyPath);
-    p12ServiceAccountConfig.setSecretP12Key(prev);
+    @Test
+    public void testCreateWithNewP12KeyFile() throws Exception {
+        when(mockFileItem.getSize()).thenReturn(1L);
+        when(mockFileItem.getName()).thenReturn(p12KeyPath);
+        when(mockFileItem.get()).thenReturn(FileUtils.readFileToByteArray(new File(p12KeyPath)));
+        P12ServiceAccountConfig p12ServiceAccountConfig = new P12ServiceAccountConfig(SERVICE_ACCOUNT_EMAIL_ADDRESS);
+        p12ServiceAccountConfig.setP12KeyFileUpload(mockFileItem);
 
-    assertNull(p12ServiceAccountConfig.getAccountId());
-    assertEquals(keyPair.getPrivate(), p12ServiceAccountConfig.getPrivateKey());
-  }
+        assertEquals(SERVICE_ACCOUNT_EMAIL_ADDRESS, p12ServiceAccountConfig.getAccountId());
+        assertEquals(keyPair.getPrivate(), p12ServiceAccountConfig.getPrivateKey());
+    }
 
-  @Test
-  @WithoutJenkins
-  public void testCreateWithNullP12KeyFile() {
-    P12ServiceAccountConfig p12ServiceAccountConfig =
-        new P12ServiceAccountConfig(SERVICE_ACCOUNT_EMAIL_ADDRESS);
+    @Test
+    public void testCreateWithNullAccountId() throws Exception {
+        SecretBytes prev = SecretBytes.fromBytes(FileUtils.readFileToByteArray(new File(p12KeyPath)));
+        P12ServiceAccountConfig p12ServiceAccountConfig = new P12ServiceAccountConfig(null);
+        p12ServiceAccountConfig.setFilename(p12KeyPath);
+        p12ServiceAccountConfig.setSecretP12Key(prev);
 
-    assertEquals(SERVICE_ACCOUNT_EMAIL_ADDRESS, p12ServiceAccountConfig.getAccountId());
-    assertNull(p12ServiceAccountConfig.getPrivateKey());
-  }
+        assertNull(p12ServiceAccountConfig.getAccountId());
+        assertEquals(keyPair.getPrivate(), p12ServiceAccountConfig.getPrivateKey());
+    }
 
-  @Test
-  @WithoutJenkins
-  public void testCreateWithEmptyP12KeyFile() throws Exception {
-    when(mockFileItem.getSize()).thenReturn(0L);
-    P12ServiceAccountConfig p12ServiceAccountConfig =
-        new P12ServiceAccountConfig(SERVICE_ACCOUNT_EMAIL_ADDRESS);
-    p12ServiceAccountConfig.setP12KeyFileUpload(mockFileItem);
+    @Test
+    @WithoutJenkins
+    public void testCreateWithNullP12KeyFile() {
+        P12ServiceAccountConfig p12ServiceAccountConfig = new P12ServiceAccountConfig(SERVICE_ACCOUNT_EMAIL_ADDRESS);
 
-    assertEquals(SERVICE_ACCOUNT_EMAIL_ADDRESS, p12ServiceAccountConfig.getAccountId());
-    assertNull(p12ServiceAccountConfig.getPrivateKey());
-  }
+        assertEquals(SERVICE_ACCOUNT_EMAIL_ADDRESS, p12ServiceAccountConfig.getAccountId());
+        assertNull(p12ServiceAccountConfig.getPrivateKey());
+    }
 
-  @Test
-  public void testCreateWithInvalidP12KeyFile() {
-    byte[] bytes = "invalidP12KeyFile".getBytes();
-    when(mockFileItem.getSize()).thenReturn((long) bytes.length);
-    when(mockFileItem.getName()).thenReturn("invalidP12KeyFile");
-    when(mockFileItem.get()).thenReturn(bytes);
-    P12ServiceAccountConfig p12ServiceAccountConfig =
-        new P12ServiceAccountConfig(SERVICE_ACCOUNT_EMAIL_ADDRESS);
-    p12ServiceAccountConfig.setP12KeyFileUpload(mockFileItem);
+    @Test
+    @WithoutJenkins
+    public void testCreateWithEmptyP12KeyFile() throws Exception {
+        when(mockFileItem.getSize()).thenReturn(0L);
+        P12ServiceAccountConfig p12ServiceAccountConfig = new P12ServiceAccountConfig(SERVICE_ACCOUNT_EMAIL_ADDRESS);
+        p12ServiceAccountConfig.setP12KeyFileUpload(mockFileItem);
 
-    assertEquals(SERVICE_ACCOUNT_EMAIL_ADDRESS, p12ServiceAccountConfig.getAccountId());
-    assertNull(p12ServiceAccountConfig.getPrivateKey());
-  }
+        assertEquals(SERVICE_ACCOUNT_EMAIL_ADDRESS, p12ServiceAccountConfig.getAccountId());
+        assertNull(p12ServiceAccountConfig.getPrivateKey());
+    }
 
-  @Test
-  public void testCreateWithPrevP12KeyFileForCompatibility() {
-    P12ServiceAccountConfig p12ServiceAccountConfig =
-        new P12ServiceAccountConfig(SERVICE_ACCOUNT_EMAIL_ADDRESS, null, p12KeyPath);
+    @Test
+    public void testCreateWithInvalidP12KeyFile() {
+        byte[] bytes = "invalidP12KeyFile".getBytes();
+        when(mockFileItem.getSize()).thenReturn((long) bytes.length);
+        when(mockFileItem.getName()).thenReturn("invalidP12KeyFile");
+        when(mockFileItem.get()).thenReturn(bytes);
+        P12ServiceAccountConfig p12ServiceAccountConfig = new P12ServiceAccountConfig(SERVICE_ACCOUNT_EMAIL_ADDRESS);
+        p12ServiceAccountConfig.setP12KeyFileUpload(mockFileItem);
 
-    assertEquals(SERVICE_ACCOUNT_EMAIL_ADDRESS, p12ServiceAccountConfig.getAccountId());
-    assertEquals(keyPair.getPrivate(), p12ServiceAccountConfig.getPrivateKey());
-  }
+        assertEquals(SERVICE_ACCOUNT_EMAIL_ADDRESS, p12ServiceAccountConfig.getAccountId());
+        assertNull(p12ServiceAccountConfig.getPrivateKey());
+    }
 
-  @Test
-  public void testCreateWithPrevP12KeyFile() throws Exception {
-    SecretBytes prev = SecretBytes.fromBytes(FileUtils.readFileToByteArray(new File(p12KeyPath)));
-    P12ServiceAccountConfig p12ServiceAccountConfig =
-        new P12ServiceAccountConfig(SERVICE_ACCOUNT_EMAIL_ADDRESS);
-    p12ServiceAccountConfig.setFilename(p12KeyPath);
-    p12ServiceAccountConfig.setSecretP12Key(prev);
+    @Test
+    public void testCreateWithPrevP12KeyFileForCompatibility() {
+        P12ServiceAccountConfig p12ServiceAccountConfig =
+                new P12ServiceAccountConfig(SERVICE_ACCOUNT_EMAIL_ADDRESS, null, p12KeyPath);
 
-    assertEquals(SERVICE_ACCOUNT_EMAIL_ADDRESS, p12ServiceAccountConfig.getAccountId());
-    assertEquals(keyPair.getPrivate(), p12ServiceAccountConfig.getPrivateKey());
-  }
+        assertEquals(SERVICE_ACCOUNT_EMAIL_ADDRESS, p12ServiceAccountConfig.getAccountId());
+        assertEquals(keyPair.getPrivate(), p12ServiceAccountConfig.getPrivateKey());
+    }
 
-  @Test
-  public void testCreateWithEmptyPrevP12KeyFile() {
-    SecretBytes prev = SecretBytes.fromString("");
-    P12ServiceAccountConfig p12ServiceAccountConfig =
-        new P12ServiceAccountConfig(SERVICE_ACCOUNT_EMAIL_ADDRESS);
-    p12ServiceAccountConfig.setFilename("");
-    p12ServiceAccountConfig.setSecretP12Key(prev);
+    @Test
+    public void testCreateWithPrevP12KeyFile() throws Exception {
+        SecretBytes prev = SecretBytes.fromBytes(FileUtils.readFileToByteArray(new File(p12KeyPath)));
+        P12ServiceAccountConfig p12ServiceAccountConfig = new P12ServiceAccountConfig(SERVICE_ACCOUNT_EMAIL_ADDRESS);
+        p12ServiceAccountConfig.setFilename(p12KeyPath);
+        p12ServiceAccountConfig.setSecretP12Key(prev);
 
-    assertEquals(SERVICE_ACCOUNT_EMAIL_ADDRESS, p12ServiceAccountConfig.getAccountId());
-    assertNull(p12ServiceAccountConfig.getPrivateKey());
-  }
+        assertEquals(SERVICE_ACCOUNT_EMAIL_ADDRESS, p12ServiceAccountConfig.getAccountId());
+        assertEquals(keyPair.getPrivate(), p12ServiceAccountConfig.getPrivateKey());
+    }
 
-  @Test
-  @WithoutJenkins
-  public void testCreateWithInvalidPrevP12KeyFile() {
-    P12ServiceAccountConfig p12ServiceAccountConfig =
-        new P12ServiceAccountConfig(SERVICE_ACCOUNT_EMAIL_ADDRESS);
-    p12ServiceAccountConfig.setFilename("invalidPrevP12KeyFile.p12");
+    @Test
+    public void testCreateWithEmptyPrevP12KeyFile() {
+        SecretBytes prev = SecretBytes.fromString("");
+        P12ServiceAccountConfig p12ServiceAccountConfig = new P12ServiceAccountConfig(SERVICE_ACCOUNT_EMAIL_ADDRESS);
+        p12ServiceAccountConfig.setFilename("");
+        p12ServiceAccountConfig.setSecretP12Key(prev);
 
-    assertEquals(SERVICE_ACCOUNT_EMAIL_ADDRESS, p12ServiceAccountConfig.getAccountId());
-    assertNull(p12ServiceAccountConfig.getPrivateKey());
-  }
+        assertEquals(SERVICE_ACCOUNT_EMAIL_ADDRESS, p12ServiceAccountConfig.getAccountId());
+        assertNull(p12ServiceAccountConfig.getPrivateKey());
+    }
 
-  @Test
-  public void testSerialization() throws Exception {
-    when(mockFileItem.getSize()).thenReturn(1L);
-    when(mockFileItem.getName()).thenReturn(p12KeyPath);
-    when(mockFileItem.get()).thenReturn(FileUtils.readFileToByteArray(new File(p12KeyPath)));
-    P12ServiceAccountConfig p12ServiceAccountConfig =
-        new P12ServiceAccountConfig(SERVICE_ACCOUNT_EMAIL_ADDRESS);
-    p12ServiceAccountConfig.setP12KeyFileUpload(mockFileItem);
+    @Test
+    @WithoutJenkins
+    public void testCreateWithInvalidPrevP12KeyFile() {
+        P12ServiceAccountConfig p12ServiceAccountConfig = new P12ServiceAccountConfig(SERVICE_ACCOUNT_EMAIL_ADDRESS);
+        p12ServiceAccountConfig.setFilename("invalidPrevP12KeyFile.p12");
 
-    ByteArrayOutputStream out = new ByteArrayOutputStream();
-    SerializationUtil.serialize(p12ServiceAccountConfig, out);
-    ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
-    P12ServiceAccountConfig deserializedP12KeyType =
-        SerializationUtil.deserialize(P12ServiceAccountConfig.class, in);
+        assertEquals(SERVICE_ACCOUNT_EMAIL_ADDRESS, p12ServiceAccountConfig.getAccountId());
+        assertNull(p12ServiceAccountConfig.getPrivateKey());
+    }
 
-    assertEquals(SERVICE_ACCOUNT_EMAIL_ADDRESS, deserializedP12KeyType.getAccountId());
-    assertEquals(keyPair.getPrivate(), deserializedP12KeyType.getPrivateKey());
-  }
+    @Test
+    public void testSerialization() throws Exception {
+        when(mockFileItem.getSize()).thenReturn(1L);
+        when(mockFileItem.getName()).thenReturn(p12KeyPath);
+        when(mockFileItem.get()).thenReturn(FileUtils.readFileToByteArray(new File(p12KeyPath)));
+        P12ServiceAccountConfig p12ServiceAccountConfig = new P12ServiceAccountConfig(SERVICE_ACCOUNT_EMAIL_ADDRESS);
+        p12ServiceAccountConfig.setP12KeyFileUpload(mockFileItem);
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        SerializationUtil.serialize(p12ServiceAccountConfig, out);
+        ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
+        P12ServiceAccountConfig deserializedP12KeyType =
+                SerializationUtil.deserialize(P12ServiceAccountConfig.class, in);
+
+        assertEquals(SERVICE_ACCOUNT_EMAIL_ADDRESS, deserializedP12KeyType.getAccountId());
+        assertEquals(keyPair.getPrivate(), deserializedP12KeyType.getPrivateKey());
+    }
 }

--- a/src/test/java/com/google/jenkins/plugins/credentials/oauth/P12ServiceAccountConfigTestUtil.java
+++ b/src/test/java/com/google/jenkins/plugins/credentials/oauth/P12ServiceAccountConfigTestUtil.java
@@ -44,76 +44,72 @@ import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
 
 /** Util class for {@link P12ServiceAccountConfigTest}. */
 public class P12ServiceAccountConfigTestUtil {
-  private static final String DEFAULT_P12_SECRET = "notasecret";
-  private static final String DEFAULT_P12_ALIAS = "privatekey";
-  private static File tempFolder;
+    private static final String DEFAULT_P12_SECRET = "notasecret";
+    private static final String DEFAULT_P12_ALIAS = "privatekey";
+    private static File tempFolder;
 
-  public static KeyPair generateKeyPair() throws NoSuchProviderException, NoSuchAlgorithmException {
-    Security.addProvider(new BouncyCastleProvider());
-    KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("RSA", "BC");
-    keyPairGenerator.initialize(1024);
-    return keyPairGenerator.generateKeyPair();
-  }
-
-  public static String createTempP12KeyFile(KeyPair keyPair)
-      throws IOException, OperatorCreationException, CertificateException, NoSuchAlgorithmException,
-          KeyStoreException, NoSuchProviderException {
-    File tempP12Key = File.createTempFile("temp-key", ".p12", getTempFolder());
-    writeKeyToFile(keyPair, tempP12Key);
-    return tempP12Key.getAbsolutePath();
-  }
-
-  private static File getTempFolder() throws IOException {
-    if (tempFolder == null) {
-      tempFolder = Files.createTempDirectory("temp" + Long.toString(System.nanoTime())).toFile();
-      tempFolder.deleteOnExit();
+    public static KeyPair generateKeyPair() throws NoSuchProviderException, NoSuchAlgorithmException {
+        Security.addProvider(new BouncyCastleProvider());
+        KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("RSA", "BC");
+        keyPairGenerator.initialize(1024);
+        return keyPairGenerator.generateKeyPair();
     }
-    return tempFolder;
-  }
 
-  private static void writeKeyToFile(KeyPair keyPair, File tempP12Key)
-      throws IOException, OperatorCreationException, CertificateException, NoSuchAlgorithmException,
-          KeyStoreException, NoSuchProviderException {
-    FileOutputStream out = null;
-    try {
-      out = new FileOutputStream(tempP12Key);
-      KeyStore keyStore = createKeyStore(keyPair);
-      keyStore.store(out, DEFAULT_P12_SECRET.toCharArray());
-    } finally {
-      IOUtils.closeQuietly(out);
+    public static String createTempP12KeyFile(KeyPair keyPair)
+            throws IOException, OperatorCreationException, CertificateException, NoSuchAlgorithmException,
+                    KeyStoreException, NoSuchProviderException {
+        File tempP12Key = File.createTempFile("temp-key", ".p12", getTempFolder());
+        writeKeyToFile(keyPair, tempP12Key);
+        return tempP12Key.getAbsolutePath();
     }
-  }
 
-  private static KeyStore createKeyStore(KeyPair keyPair)
-      throws KeyStoreException, CertificateException, NoSuchAlgorithmException, IOException,
-          OperatorCreationException, NoSuchProviderException {
-    KeyStore keyStore = KeyStore.getInstance("PKCS12");
-    keyStore.load(null, null);
-    keyStore.setKeyEntry(
-        DEFAULT_P12_ALIAS,
-        keyPair.getPrivate(),
-        DEFAULT_P12_SECRET.toCharArray(),
-        new Certificate[] {generateCertificate(keyPair)});
-    return keyStore;
-  }
+    private static File getTempFolder() throws IOException {
+        if (tempFolder == null) {
+            tempFolder = Files.createTempDirectory("temp" + Long.toString(System.nanoTime()))
+                    .toFile();
+            tempFolder.deleteOnExit();
+        }
+        return tempFolder;
+    }
 
-  private static X509Certificate generateCertificate(KeyPair keyPair)
-      throws OperatorCreationException, CertificateException {
-    Calendar endCalendar = Calendar.getInstance();
-    endCalendar.add(Calendar.YEAR, 10);
-    X509v3CertificateBuilder x509v3CertificateBuilder =
-        new X509v3CertificateBuilder(
-            new X500Name("CN=localhost"),
-            BigInteger.valueOf(1),
-            Calendar.getInstance().getTime(),
-            endCalendar.getTime(),
-            new X500Name("CN=localhost"),
-            SubjectPublicKeyInfo.getInstance(keyPair.getPublic().getEncoded()));
-    ContentSigner contentSigner =
-        new JcaContentSignerBuilder("SHA1withRSA").build(keyPair.getPrivate());
-    X509CertificateHolder x509CertificateHolder = x509v3CertificateBuilder.build(contentSigner);
-    return new JcaX509CertificateConverter()
-        .setProvider("BC")
-        .getCertificate(x509CertificateHolder);
-  }
+    private static void writeKeyToFile(KeyPair keyPair, File tempP12Key)
+            throws IOException, OperatorCreationException, CertificateException, NoSuchAlgorithmException,
+                    KeyStoreException, NoSuchProviderException {
+        FileOutputStream out = null;
+        try {
+            out = new FileOutputStream(tempP12Key);
+            KeyStore keyStore = createKeyStore(keyPair);
+            keyStore.store(out, DEFAULT_P12_SECRET.toCharArray());
+        } finally {
+            IOUtils.closeQuietly(out);
+        }
+    }
+
+    private static KeyStore createKeyStore(KeyPair keyPair)
+            throws KeyStoreException, CertificateException, NoSuchAlgorithmException, IOException,
+                    OperatorCreationException, NoSuchProviderException {
+        KeyStore keyStore = KeyStore.getInstance("PKCS12");
+        keyStore.load(null, null);
+        keyStore.setKeyEntry(
+                DEFAULT_P12_ALIAS, keyPair.getPrivate(), DEFAULT_P12_SECRET.toCharArray(), new Certificate[] {
+                    generateCertificate(keyPair)
+                });
+        return keyStore;
+    }
+
+    private static X509Certificate generateCertificate(KeyPair keyPair)
+            throws OperatorCreationException, CertificateException {
+        Calendar endCalendar = Calendar.getInstance();
+        endCalendar.add(Calendar.YEAR, 10);
+        X509v3CertificateBuilder x509v3CertificateBuilder = new X509v3CertificateBuilder(
+                new X500Name("CN=localhost"),
+                BigInteger.valueOf(1),
+                Calendar.getInstance().getTime(),
+                endCalendar.getTime(),
+                new X500Name("CN=localhost"),
+                SubjectPublicKeyInfo.getInstance(keyPair.getPublic().getEncoded()));
+        ContentSigner contentSigner = new JcaContentSignerBuilder("SHA1withRSA").build(keyPair.getPrivate());
+        X509CertificateHolder x509CertificateHolder = x509v3CertificateBuilder.build(contentSigner);
+        return new JcaX509CertificateConverter().setProvider("BC").getCertificate(x509CertificateHolder);
+    }
 }

--- a/src/test/java/com/google/jenkins/plugins/credentials/oauth/SerializationUtil.java
+++ b/src/test/java/com/google/jenkins/plugins/credentials/oauth/SerializationUtil.java
@@ -19,34 +19,34 @@ import java.io.*;
 
 /** Helper class for Serialization */
 public class SerializationUtil {
-  public static void serialize(Object object, OutputStream out) throws IOException {
-    ObjectOutputStream objectOut = null;
-    try {
-      objectOut = new ObjectOutputStream(out);
-      objectOut.writeObject(object);
-    } finally {
-      if (objectOut != null) {
+    public static void serialize(Object object, OutputStream out) throws IOException {
+        ObjectOutputStream objectOut = null;
         try {
-          objectOut.close();
-        } catch (IOException ignored) {
+            objectOut = new ObjectOutputStream(out);
+            objectOut.writeObject(object);
+        } finally {
+            if (objectOut != null) {
+                try {
+                    objectOut.close();
+                } catch (IOException ignored) {
+                }
+            }
         }
-      }
     }
-  }
 
-  public static <T> T deserialize(Class<T> clazz, InputStream in)
-      throws IOException, ClassNotFoundException, ClassCastException {
-    ObjectInputStream objectIn = null;
-    try {
-      objectIn = new ObjectInputStream(in);
-      return clazz.cast(objectIn.readObject());
-    } finally {
-      if (objectIn != null) {
+    public static <T> T deserialize(Class<T> clazz, InputStream in)
+            throws IOException, ClassNotFoundException, ClassCastException {
+        ObjectInputStream objectIn = null;
         try {
-          objectIn.close();
-        } catch (IOException ignored) {
+            objectIn = new ObjectInputStream(in);
+            return clazz.cast(objectIn.readObject());
+        } finally {
+            if (objectIn != null) {
+                try {
+                    objectIn.close();
+                } catch (IOException ignored) {
+                }
+            }
         }
-      }
     }
-  }
 }

--- a/src/test/java/com/google/jenkins/plugins/credentials/oauth/TestGoogleOAuth2DomainRequirement.java
+++ b/src/test/java/com/google/jenkins/plugins/credentials/oauth/TestGoogleOAuth2DomainRequirement.java
@@ -20,16 +20,16 @@ import java.util.Collections;
 
 /** This is a trivial implementation of a {@link GoogleOAuth2ScopeRequirement}. */
 public class TestGoogleOAuth2DomainRequirement extends GoogleOAuth2ScopeRequirement {
-  private static final long serialVersionUID = 2234181311205118742L;
+    private static final long serialVersionUID = 2234181311205118742L;
 
-  public TestGoogleOAuth2DomainRequirement(String scope) {
-    this.scope = scope;
-  }
+    public TestGoogleOAuth2DomainRequirement(String scope) {
+        this.scope = scope;
+    }
 
-  @Override
-  public Collection<String> getScopes() {
-    return Collections.singletonList(scope);
-  }
+    @Override
+    public Collection<String> getScopes() {
+        return Collections.singletonList(scope);
+    }
 
-  private final String scope;
+    private final String scope;
 }

--- a/src/test/java/com/google/jenkins/plugins/credentials/oauth/TestRobotBuilder.java
+++ b/src/test/java/com/google/jenkins/plugins/credentials/oauth/TestRobotBuilder.java
@@ -25,20 +25,20 @@ import hudson.tasks.Builder;
  */
 @RequiresDomain(value = TestGoogleOAuth2DomainRequirement.class)
 public class TestRobotBuilder extends Builder {
-  public TestRobotBuilder() {}
+    public TestRobotBuilder() {}
 
-  @Override
-  public DescriptorImpl getDescriptor() {
-    return DESCRIPTOR;
-  }
-
-  /** Descriptor for our trivial builder */
-  public static final class DescriptorImpl extends Descriptor<Builder> {
     @Override
-    public String getDisplayName() {
-      return "Test Robot Builder";
+    public DescriptorImpl getDescriptor() {
+        return DESCRIPTOR;
     }
-  }
 
-  public static final DescriptorImpl DESCRIPTOR = new DescriptorImpl();
+    /** Descriptor for our trivial builder */
+    public static final class DescriptorImpl extends Descriptor<Builder> {
+        @Override
+        public String getDisplayName() {
+            return "Test Robot Builder";
+        }
+    }
+
+    public static final DescriptorImpl DESCRIPTOR = new DescriptorImpl();
 }

--- a/src/test/java/com/google/jenkins/plugins/util/ExecutorTest.java
+++ b/src/test/java/com/google/jenkins/plugins/util/ExecutorTest.java
@@ -32,94 +32,93 @@ import org.mockito.MockitoAnnotations;
 /** Tests for {@link Executor}. */
 public class ExecutorTest {
 
-  private HttpResponseException notFoundJsonException;
-  private HttpResponseException conflictJsonException;
-  private HttpResponseException forbiddenJsonException;
-  private HttpResponseException errorJsonException;
-  private SocketTimeoutException timeoutException;
+    private HttpResponseException notFoundJsonException;
+    private HttpResponseException conflictJsonException;
+    private HttpResponseException forbiddenJsonException;
+    private HttpResponseException errorJsonException;
+    private SocketTimeoutException timeoutException;
 
-  @Mock private com.google.api.client.http.HttpHeaders headers;
+    @Mock
+    private com.google.api.client.http.HttpHeaders headers;
 
-  @Mock private AbstractGoogleJsonClientRequest<Void> mockRequest;
+    @Mock
+    private AbstractGoogleJsonClientRequest<Void> mockRequest;
 
-  private Executor underTest;
+    private Executor underTest;
 
-  @Before
-  public void setUp() throws Exception {
-    MockitoAnnotations.initMocks(this);
+    @Before
+    public void setUp() throws Exception {
+        MockitoAnnotations.initMocks(this);
 
-    notFoundJsonException =
-        new HttpResponseException.Builder(STATUS_CODE_NOT_FOUND, STATUS_MESSAGE, headers).build();
-    conflictJsonException =
-        new HttpResponseException.Builder(409 /* STATUS_CODE_CONFLICT */, STATUS_MESSAGE, headers)
-            .build();
-    forbiddenJsonException =
-        new HttpResponseException.Builder(STATUS_CODE_FORBIDDEN, STATUS_MESSAGE, headers).build();
-    errorJsonException =
-        new HttpResponseException.Builder(STATUS_CODE_SERVER_ERROR, STATUS_MESSAGE, headers)
-            .build();
+        notFoundJsonException =
+                new HttpResponseException.Builder(STATUS_CODE_NOT_FOUND, STATUS_MESSAGE, headers).build();
+        conflictJsonException =
+                new HttpResponseException.Builder(409 /* STATUS_CODE_CONFLICT */, STATUS_MESSAGE, headers).build();
+        forbiddenJsonException =
+                new HttpResponseException.Builder(STATUS_CODE_FORBIDDEN, STATUS_MESSAGE, headers).build();
+        errorJsonException =
+                new HttpResponseException.Builder(STATUS_CODE_SERVER_ERROR, STATUS_MESSAGE, headers).build();
 
-    timeoutException = new SocketTimeoutException(STATUS_MESSAGE);
+        timeoutException = new SocketTimeoutException(STATUS_MESSAGE);
 
-    underTest =
-        new Executor.Default() {
-          @Override
-          public void sleep() {
-            // Don't really sleep...
-          }
+        underTest = new Executor.Default() {
+            @Override
+            public void sleep() {
+                // Don't really sleep...
+            }
         };
-  }
+    }
 
-  @Test
-  public void testVanillaNewExecutor() throws Exception {
-    assertNotNull(underTest);
-    when(mockRequest.execute()).thenReturn((Void) null);
+    @Test
+    public void testVanillaNewExecutor() throws Exception {
+        assertNotNull(underTest);
+        when(mockRequest.execute()).thenReturn((Void) null);
 
-    underTest.execute(mockRequest);
-  }
+        underTest.execute(mockRequest);
+    }
 
-  @Test(expected = NotFoundException.class)
-  public void testNewExecutorWithNotFound() throws Exception {
-    assertNotNull(underTest);
-    when(mockRequest.execute()).thenThrow(notFoundJsonException);
+    @Test(expected = NotFoundException.class)
+    public void testNewExecutorWithNotFound() throws Exception {
+        assertNotNull(underTest);
+        when(mockRequest.execute()).thenThrow(notFoundJsonException);
 
-    underTest.execute(mockRequest);
-  }
+        underTest.execute(mockRequest);
+    }
 
-  @Test(expected = ConflictException.class)
-  public void testNewExecutorWithConflict() throws Exception {
-    assertNotNull(underTest);
-    when(mockRequest.execute()).thenThrow(conflictJsonException);
+    @Test(expected = ConflictException.class)
+    public void testNewExecutorWithConflict() throws Exception {
+        assertNotNull(underTest);
+        when(mockRequest.execute()).thenThrow(conflictJsonException);
 
-    underTest.execute(mockRequest);
-  }
+        underTest.execute(mockRequest);
+    }
 
-  @Test(expected = ForbiddenException.class)
-  public void testNewExecutorWithForbidden() throws Exception {
-    assertNotNull(underTest);
-    when(mockRequest.execute()).thenThrow(forbiddenJsonException);
+    @Test(expected = ForbiddenException.class)
+    public void testNewExecutorWithForbidden() throws Exception {
+        assertNotNull(underTest);
+        when(mockRequest.execute()).thenThrow(forbiddenJsonException);
 
-    underTest.execute(mockRequest);
-  }
+        underTest.execute(mockRequest);
+    }
 
-  @Test(expected = HttpResponseException.class)
-  public void testNewExecutorWithAllErrors() throws Exception {
-    assertNotNull(underTest);
-    when(mockRequest.execute()).thenThrow(errorJsonException);
+    @Test(expected = HttpResponseException.class)
+    public void testNewExecutorWithAllErrors() throws Exception {
+        assertNotNull(underTest);
+        when(mockRequest.execute()).thenThrow(errorJsonException);
 
-    underTest.execute(mockRequest);
-  }
+        underTest.execute(mockRequest);
+    }
 
-  @Test
-  public void testNewExecutorWithErrorsThenSuccess() throws Exception {
-    assertNotNull(underTest);
-    when(mockRequest.execute())
-        .thenThrow(errorJsonException)
-        .thenThrow(timeoutException)
-        .thenReturn((Void) null);
+    @Test
+    public void testNewExecutorWithErrorsThenSuccess() throws Exception {
+        assertNotNull(underTest);
+        when(mockRequest.execute())
+                .thenThrow(errorJsonException)
+                .thenThrow(timeoutException)
+                .thenReturn((Void) null);
 
-    underTest.execute(mockRequest);
-  }
+        underTest.execute(mockRequest);
+    }
 
-  private static final String STATUS_MESSAGE = "doesn't matter";
+    private static final String STATUS_MESSAGE = "doesn't matter";
 }

--- a/src/test/java/com/google/jenkins/plugins/util/MetadataReaderTest.java
+++ b/src/test/java/com/google/jenkins/plugins/util/MetadataReaderTest.java
@@ -36,98 +36,98 @@ import org.mockito.MockitoAnnotations;
 
 /** Tests for {@link MetadataReader}. */
 public class MetadataReaderTest {
-  private MockHttpTransport transport;
-  private MockLowLevelHttpRequest request;
+    private MockHttpTransport transport;
+    private MockLowLevelHttpRequest request;
 
-  private void stubRequest(String url, int statusCode, String responseContent) throws IOException {
-    request.setResponse(
-        new MockLowLevelHttpResponse().setStatusCode(statusCode).setContent(responseContent));
-    doReturn(request).when(transport).buildRequest("GET", url);
-  }
-
-  private void verifyRequest(String key) throws IOException {
-    verify(transport).buildRequest("GET", METADATA_ENDPOINT + key);
-    verify(request).execute();
-    assertEquals("Google", getOnlyElement(request.getHeaderValues("Metadata-Flavor")));
-  }
-
-  private MetadataReader underTest;
-
-  @Before
-  public void setUp() throws Exception {
-    MockitoAnnotations.initMocks(this);
-    transport = spy(new MockHttpTransport());
-    request = spy(new MockLowLevelHttpRequest());
-
-    underTest = new MetadataReader.Default(transport.createRequestFactory());
-  }
-
-  @Test
-  public void testHasMetadata() throws Exception {
-    stubRequest(METADATA_ENDPOINT, STATUS_CODE_OK, "hi");
-
-    assertTrue(underTest.hasMetadata());
-    verifyRequest("");
-  }
-
-  @Test
-  public void testHasNoMetadata() throws Exception {
-    stubRequest(METADATA_ENDPOINT, STATUS_CODE_NOT_FOUND, "hi");
-
-    assertFalse(underTest.hasMetadata());
-    verifyRequest("");
-  }
-
-  @Test
-  public void testHasNoMetadata2() throws Exception {
-    stubRequest(METADATA_ENDPOINT, 409, "hi");
-
-    assertFalse(underTest.hasMetadata());
-    verifyRequest("");
-  }
-
-  @Test
-  public void testReadMetadata() throws Exception {
-    stubRequest(METADATA_ENDPOINT + MY_KEY, STATUS_CODE_OK, MY_VALUE);
-
-    assertEquals(MY_VALUE, underTest.readMetadata(MY_KEY));
-    verifyRequest(MY_KEY);
-  }
-
-  @Test(expected = NotFoundException.class)
-  public void testReadMissingMetadata() throws Exception {
-    stubRequest(METADATA_ENDPOINT + MY_KEY, STATUS_CODE_NOT_FOUND, MY_VALUE);
-
-    try {
-      underTest.readMetadata(MY_KEY);
-    } finally {
-      verifyRequest(MY_KEY);
+    private void stubRequest(String url, int statusCode, String responseContent) throws IOException {
+        request.setResponse(
+                new MockLowLevelHttpResponse().setStatusCode(statusCode).setContent(responseContent));
+        doReturn(request).when(transport).buildRequest("GET", url);
     }
-  }
 
-  @Test(expected = ForbiddenException.class)
-  public void testReadUnauthorizedMetadata() throws Exception {
-    stubRequest(METADATA_ENDPOINT + MY_KEY, STATUS_CODE_UNAUTHORIZED, MY_VALUE);
-
-    try {
-      underTest.readMetadata(MY_KEY);
-    } finally {
-      verifyRequest(MY_KEY);
+    private void verifyRequest(String key) throws IOException {
+        verify(transport).buildRequest("GET", METADATA_ENDPOINT + key);
+        verify(request).execute();
+        assertEquals("Google", getOnlyElement(request.getHeaderValues("Metadata-Flavor")));
     }
-  }
 
-  @Test(expected = IOException.class)
-  public void testReadUnrecognizedMetadataException() throws Exception {
-    stubRequest(METADATA_ENDPOINT + MY_KEY, 409, MY_VALUE);
+    private MetadataReader underTest;
 
-    try {
-      underTest.readMetadata(MY_KEY);
-    } finally {
-      verifyRequest(MY_KEY);
+    @Before
+    public void setUp() throws Exception {
+        MockitoAnnotations.initMocks(this);
+        transport = spy(new MockHttpTransport());
+        request = spy(new MockLowLevelHttpRequest());
+
+        underTest = new MetadataReader.Default(transport.createRequestFactory());
     }
-  }
 
-  private static String METADATA_ENDPOINT = "http://metadata/computeMetadata/v1";
-  private static String MY_KEY = "/my/metadata/path";
-  private static String MY_VALUE = "RaNdOm value";
+    @Test
+    public void testHasMetadata() throws Exception {
+        stubRequest(METADATA_ENDPOINT, STATUS_CODE_OK, "hi");
+
+        assertTrue(underTest.hasMetadata());
+        verifyRequest("");
+    }
+
+    @Test
+    public void testHasNoMetadata() throws Exception {
+        stubRequest(METADATA_ENDPOINT, STATUS_CODE_NOT_FOUND, "hi");
+
+        assertFalse(underTest.hasMetadata());
+        verifyRequest("");
+    }
+
+    @Test
+    public void testHasNoMetadata2() throws Exception {
+        stubRequest(METADATA_ENDPOINT, 409, "hi");
+
+        assertFalse(underTest.hasMetadata());
+        verifyRequest("");
+    }
+
+    @Test
+    public void testReadMetadata() throws Exception {
+        stubRequest(METADATA_ENDPOINT + MY_KEY, STATUS_CODE_OK, MY_VALUE);
+
+        assertEquals(MY_VALUE, underTest.readMetadata(MY_KEY));
+        verifyRequest(MY_KEY);
+    }
+
+    @Test(expected = NotFoundException.class)
+    public void testReadMissingMetadata() throws Exception {
+        stubRequest(METADATA_ENDPOINT + MY_KEY, STATUS_CODE_NOT_FOUND, MY_VALUE);
+
+        try {
+            underTest.readMetadata(MY_KEY);
+        } finally {
+            verifyRequest(MY_KEY);
+        }
+    }
+
+    @Test(expected = ForbiddenException.class)
+    public void testReadUnauthorizedMetadata() throws Exception {
+        stubRequest(METADATA_ENDPOINT + MY_KEY, STATUS_CODE_UNAUTHORIZED, MY_VALUE);
+
+        try {
+            underTest.readMetadata(MY_KEY);
+        } finally {
+            verifyRequest(MY_KEY);
+        }
+    }
+
+    @Test(expected = IOException.class)
+    public void testReadUnrecognizedMetadataException() throws Exception {
+        stubRequest(METADATA_ENDPOINT + MY_KEY, 409, MY_VALUE);
+
+        try {
+            underTest.readMetadata(MY_KEY);
+        } finally {
+            verifyRequest(MY_KEY);
+        }
+    }
+
+    private static String METADATA_ENDPOINT = "http://metadata/computeMetadata/v1";
+    private static String MY_KEY = "/my/metadata/path";
+    private static String MY_VALUE = "RaNdOm value";
 }

--- a/src/test/java/com/google/jenkins/plugins/util/MockExecutorTest.java
+++ b/src/test/java/com/google/jenkins/plugins/util/MockExecutorTest.java
@@ -36,116 +36,119 @@ import org.mockito.MockitoAnnotations;
 /** Tests for the {@link MockExecutor}. */
 public class MockExecutorTest {
 
-  @Rule public ExpectedException thrown = ExpectedException.none();
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
 
-  @Mock private AbstractGoogleJsonClientRequest<String> mockRequest;
+    @Mock
+    private AbstractGoogleJsonClientRequest<String> mockRequest;
 
-  private static class FakeRequest extends AbstractGoogleJsonClientRequest<String> {
-    private FakeRequest(AbstractGoogleJsonClient client, String s, String t, Object o) {
-      super(client, s, t, o, String.class);
+    private static class FakeRequest extends AbstractGoogleJsonClientRequest<String> {
+        private FakeRequest(AbstractGoogleJsonClient client, String s, String t, Object o) {
+            super(client, s, t, o, String.class);
+        }
     }
-  };
+    ;
 
-  @Mock private FakeRequest otherMockRequest;
+    @Mock
+    private FakeRequest otherMockRequest;
 
-  private static final String theString = "tHe StRiNg!";
-  private static final String theOtherString = "tHe OtHeR sTrInG!";
+    private static final String theString = "tHe StRiNg!";
+    private static final String theOtherString = "tHe OtHeR sTrInG!";
 
-  private MockExecutor executor = new MockExecutor();
+    private MockExecutor executor = new MockExecutor();
 
-  @Rule
-  public Verifier verifySawAll =
-      new Verifier() {
+    @Rule
+    public Verifier verifySawAll = new Verifier() {
         @Override
         public void verify() {
-          assertTrue(executor.sawAll());
+            assertTrue(executor.sawAll());
         }
-      };
+    };
 
-  @Before
-  public void setUp() throws Exception {
-    MockitoAnnotations.initMocks(this);
-  }
-
-  @Test
-  public void testEmpty() throws Exception {
-    thrown.expect(IllegalStateException.class);
-    thrown.expectMessage(containsString("Unexpected request"));
-
-    try {
-      executor.execute(mockRequest);
-    } finally {
-      assertTrue(executor.sawUnexpected());
+    @Before
+    public void setUp() throws Exception {
+        MockitoAnnotations.initMocks(this);
     }
-  }
 
-  @Test
-  public void testFailingPredicate() throws Exception {
-    // Make sure that when a false predicate occurs, we throw
-    // an exception
-    executor.when(
-        mockRequest.getClass(),
-        theOtherString,
-        Predicates.<AbstractGoogleJsonClientRequest<String>>alwaysFalse());
+    @Test
+    public void testEmpty() throws Exception {
+        thrown.expect(IllegalStateException.class);
+        thrown.expectMessage(containsString("Unexpected request"));
 
-    thrown.expect(IllegalStateException.class);
-    thrown.expectMessage(containsString("User predicate"));
-
-    try {
-      executor.execute(mockRequest);
-    } finally {
-      assertTrue(executor.sawUnexpected());
+        try {
+            executor.execute(mockRequest);
+        } finally {
+            assertTrue(executor.sawUnexpected());
+        }
     }
-  }
 
-  @Test
-  public void testWhen() throws Exception {
-    executor.when(mockRequest.getClass(), theOtherString);
+    @Test
+    public void testFailingPredicate() throws Exception {
+        // Make sure that when a false predicate occurs, we throw
+        // an exception
+        executor.when(
+                mockRequest.getClass(),
+                theOtherString,
+                Predicates.<AbstractGoogleJsonClientRequest<String>>alwaysFalse());
 
-    assertEquals(theOtherString, executor.execute(mockRequest));
-    assertFalse(executor.sawUnexpected());
-  }
+        thrown.expect(IllegalStateException.class);
+        thrown.expectMessage(containsString("User predicate"));
 
-  @Test
-  public void testOutOfOrder() throws Exception {
-    executor.when(otherMockRequest.getClass(), theOtherString);
-
-    thrown.expect(IllegalStateException.class);
-    thrown.expectMessage(containsString("out of order"));
-
-    executor.execute(mockRequest);
-    assertFalse(executor.sawUnexpected());
-  }
-
-  private static final class MyException extends IOException {
-    public MyException(String message) {
-      super(message);
+        try {
+            executor.execute(mockRequest);
+        } finally {
+            assertTrue(executor.sawUnexpected());
+        }
     }
-  }
 
-  @Test
-  public void testThrowWhen() throws Exception {
-    executor.throwWhen(mockRequest.getClass(), new MyException(theString));
+    @Test
+    public void testWhen() throws Exception {
+        executor.when(mockRequest.getClass(), theOtherString);
 
-    thrown.expect(MyException.class);
-    thrown.expectMessage(theString);
-
-    try {
-      executor.execute(mockRequest);
-    } finally {
-      assertFalse(executor.sawUnexpected());
+        assertEquals(theOtherString, executor.execute(mockRequest));
+        assertFalse(executor.sawUnexpected());
     }
-  }
 
-  @Test
-  public void testPassThruWhen() throws Exception {
-    when(mockRequest.getJsonContent()).thenReturn(theString);
-    executor.passThruWhen(mockRequest.getClass());
+    @Test
+    public void testOutOfOrder() throws Exception {
+        executor.when(otherMockRequest.getClass(), theOtherString);
 
-    try {
-      assertEquals(theString, executor.execute(mockRequest));
-    } finally {
-      assertFalse(executor.sawUnexpected());
+        thrown.expect(IllegalStateException.class);
+        thrown.expectMessage(containsString("out of order"));
+
+        executor.execute(mockRequest);
+        assertFalse(executor.sawUnexpected());
     }
-  }
+
+    private static final class MyException extends IOException {
+        public MyException(String message) {
+            super(message);
+        }
+    }
+
+    @Test
+    public void testThrowWhen() throws Exception {
+        executor.throwWhen(mockRequest.getClass(), new MyException(theString));
+
+        thrown.expect(MyException.class);
+        thrown.expectMessage(theString);
+
+        try {
+            executor.execute(mockRequest);
+        } finally {
+            assertFalse(executor.sawUnexpected());
+        }
+    }
+
+    @Test
+    public void testPassThruWhen() throws Exception {
+        when(mockRequest.getJsonContent()).thenReturn(theString);
+        executor.passThruWhen(mockRequest.getClass());
+
+        try {
+            assertEquals(theString, executor.execute(mockRequest));
+        } finally {
+            assertFalse(executor.sawUnexpected());
+        }
+    }
 }

--- a/src/test/java/com/google/jenkins/plugins/util/NameValuePairTest.java
+++ b/src/test/java/com/google/jenkins/plugins/util/NameValuePairTest.java
@@ -21,23 +21,23 @@ import org.junit.Test;
 
 /** Tests for {@link NameValuePair} */
 public class NameValuePairTest {
-  @Test
-  public void testBasicString() {
-    final String first = "a";
-    final String second = "b";
-    NameValuePair<String, String> pair = new NameValuePair<String, String>(first, second);
+    @Test
+    public void testBasicString() {
+        final String first = "a";
+        final String second = "b";
+        NameValuePair<String, String> pair = new NameValuePair<String, String>(first, second);
 
-    assertSame(first, pair.getName());
-    assertSame(second, pair.getValue());
-  }
+        assertSame(first, pair.getName());
+        assertSame(second, pair.getValue());
+    }
 
-  @Test
-  public void testBasicWithObject() {
-    final String first = "a";
-    final Object second = new Object();
-    NameValuePair<String, Object> pair = new NameValuePair<String, Object>(first, second);
+    @Test
+    public void testBasicWithObject() {
+        final String first = "a";
+        final Object second = new Object();
+        NameValuePair<String, Object> pair = new NameValuePair<String, Object>(first, second);
 
-    assertSame(first, pair.getName());
-    assertSame(second, pair.getValue());
-  }
+        assertSame(first, pair.getName());
+        assertSame(second, pair.getValue());
+    }
 }

--- a/src/test/java/com/google/jenkins/plugins/util/ResolveTest.java
+++ b/src/test/java/com/google/jenkins/plugins/util/ResolveTest.java
@@ -27,42 +27,39 @@ import org.mockito.MockitoAnnotations;
 /** Tests for {@link Resolve}'s static methods. */
 public class ResolveTest {
 
-  @Before
-  public void setUp() throws Exception {
-    MockitoAnnotations.initMocks(this);
-  }
+    @Before
+    public void setUp() throws Exception {
+        MockitoAnnotations.initMocks(this);
+    }
 
-  @Test
-  public void testBasicResolve() {
-    String basicInput = "la dee da $BUILD_NUMBER";
+    @Test
+    public void testBasicResolve() {
+        String basicInput = "la dee da $BUILD_NUMBER";
 
-    assertThat(
-        Resolve.resolveBuiltin(basicInput), Matchers.not(Matchers.containsString("BUILD_NUMBER")));
-  }
+        assertThat(Resolve.resolveBuiltin(basicInput), Matchers.not(Matchers.containsString("BUILD_NUMBER")));
+    }
 
-  @Test
-  public void testUserOverride() {
-    String basicInput = "$BUILD_NUMBER";
+    @Test
+    public void testUserOverride() {
+        String basicInput = "$BUILD_NUMBER";
 
-    assertEquals(
-        OVERRIDE,
-        Resolve.resolveBuiltinWithCustom(
-            basicInput, Collections.singletonMap("BUILD_NUMBER", OVERRIDE)));
-  }
+        assertEquals(
+                OVERRIDE,
+                Resolve.resolveBuiltinWithCustom(basicInput, Collections.singletonMap("BUILD_NUMBER", OVERRIDE)));
+    }
 
-  @Test
-  public void testJustUserOverrides() {
-    String basicInput = "$bar";
+    @Test
+    public void testJustUserOverrides() {
+        String basicInput = "$bar";
 
-    assertEquals(
-        OVERRIDE, Resolve.resolveCustom(basicInput, Collections.singletonMap("bar", OVERRIDE)));
-  }
+        assertEquals(OVERRIDE, Resolve.resolveCustom(basicInput, Collections.singletonMap("bar", OVERRIDE)));
+    }
 
-  @Test
-  public void testNoVariable() {
-    assertEquals(UNKNOWN_VAR, Resolve.resolveBuiltin(UNKNOWN_VAR));
-  }
+    @Test
+    public void testNoVariable() {
+        assertEquals(UNKNOWN_VAR, Resolve.resolveBuiltin(UNKNOWN_VAR));
+    }
 
-  private static final String OVERRIDE = "my variable override";
-  private static final String UNKNOWN_VAR = "$foo";
+    private static final String OVERRIDE = "my variable override";
+    private static final String UNKNOWN_VAR = "$foo";
 }


### PR DESCRIPTION
This repository uses a non-standard (for the Jenkins project) code formatting style and enforcement during the build. This PR switches this repository to use the Jenkins standard project-wide formatting configuration and enforcement with Spotless. The benefit is that it makes it easier for Jenkins developers to go from one project to the next without the cognitive dissonance of switching styles.

### Testing done

Ran `mvn clean verify -DskipTests`.