### PR TITLE
Slim down JPI

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
     <hpi.compatibleSinceVersion>1.0.0</hpi.compatibleSinceVersion>
     <google.api.version>1.35.2</google.api.version>
     <oauth2.revision>151</oauth2.revision>
-    <google.http.version>1.21.0</google.http.version>
+    <google.http.version>1.42.2</google.http.version>
     <spotbugs.effort>Max</spotbugs.effort>
     <runSuite>**/GoogleOAuthPluginTestSuite.class</runSuite>
     <spotless.check.skip>false</spotless.check.skip>
@@ -82,20 +82,27 @@
 
   <dependencyManagement>
     <dependencies>
-      <!-- Ensures version compatibility: https://googleapis.github.io/google-http-java-client/setup.html -->
-      <dependency>
-        <groupId>com.google.cloud</groupId>
-        <artifactId>libraries-bom</artifactId>
-        <version>26.1.1</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-${jenkins.baseline}.x</artifactId>
         <version>3944.v1a_e4f8b_452db_</version>
         <type>pom</type>
         <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>com.google.http-client</groupId>
+        <artifactId>google-http-client-apache-v2</artifactId>
+        <version>${google.http.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.http-client</groupId>
+        <artifactId>google-http-client-gson</artifactId>
+        <version>${google.http.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.grpc</groupId>
+        <artifactId>grpc-context</artifactId>
+        <version>1.48.0</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -110,6 +117,11 @@
         <exclusion>
           <groupId>com.google.code.findbugs</groupId>
           <artifactId>jsr305</artifactId>
+        </exclusion>
+        <!-- Provided by gson-api plugin -->
+        <exclusion>
+          <groupId>com.google.code.gson</groupId>
+          <artifactId>gson</artifactId>
         </exclusion>
         <!-- Provided by core -->
         <exclusion>
@@ -148,6 +160,7 @@
     <dependency>
       <groupId>com.google.http-client</groupId>
       <artifactId>google-http-client</artifactId>
+      <version>${google.http.version}</version>
       <exclusions>
         <!-- Provided by jackson2-api plugin -->
         <exclusion>
@@ -195,6 +208,11 @@
       <artifactId>google-oauth-client</artifactId>
       <version>1.34.1</version>
       <exclusions>
+        <!-- Provided by gson-api plugin -->
+        <exclusion>
+          <groupId>com.google.code.gson</groupId>
+          <artifactId>gson</artifactId>
+        </exclusion>
         <!-- Provided by core -->
         <exclusion>
           <groupId>com.google.guava</groupId>
@@ -206,26 +224,26 @@
         </exclusion>
       </exclusions>
     </dependency>
-    <!-- org.joda.time -->
     <dependency>
-      <groupId>joda-time</groupId>
-      <artifactId>joda-time</artifactId>
-      <!-- XStream has deserialization warnings for Jodatime 2.0 or later -->
-      <version>2.12.5</version>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>apache-httpcomponents-client-4-api</artifactId>
-    </dependency>
-    <!-- plugin dependencies -->
-    <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>credentials</artifactId>
+      <groupId>io.jenkins.plugins</groupId>
+      <artifactId>gson-api</artifactId>
     </dependency>
     <!--
       Use API plugins for oft-used transitive dependencies:
       https://www.jenkins.io/doc/developer/plugin-development/dependencies-and-class-loading/#using-library-wrapper-plugins
     -->
+    <dependency>
+      <groupId>io.jenkins.plugins</groupId>
+      <artifactId>joda-time-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>apache-httpcomponents-client-4-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>credentials</artifactId>
+    </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>jackson2-api</artifactId>


### PR DESCRIPTION
Use GSON and Joda Time library plugins rather than duplicating them in this JPI. Only those two JARs have been removed, all other JARs are the same. To avoid enforcer errors, had to remove `libraries-bom` and manage dependencies explicitly.