### PR TITLE
Test with Java 25

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,5 @@
 buildPlugin(useContainerAgent: true, configurations: [
   [platform: 'linux', jdk: 21],
   [platform: 'windows', jdk: 17],
+  [platform: 'linux', jdk: 25],
 ])

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>5.8</version>
+    <version>5.24</version>
   </parent>
 
   <!--

--- a/pom.xml
+++ b/pom.xml
@@ -69,8 +69,8 @@
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/google-oauth-plugin</gitHubRepo>
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
-    <jenkins.baseline>2.479</jenkins.baseline>
-    <jenkins.version>${jenkins.baseline}.1</jenkins.version>
+    <jenkins.baseline>2.504</jenkins.baseline>
+    <jenkins.version>${jenkins.baseline}.3</jenkins.version>
     <hpi.compatibleSinceVersion>1.0.0</hpi.compatibleSinceVersion>
     <google.api.version>1.35.2</google.api.version>
     <oauth2.revision>151</oauth2.revision>
@@ -85,7 +85,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-${jenkins.baseline}.x</artifactId>
-        <version>3944.v1a_e4f8b_452db_</version>
+        <version>5294.va_d2e144c80e1</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,7 @@
     <revision>1</revision>
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/google-oauth-plugin</gitHubRepo>
+    <hpi.bundledArtifacts>google-api-client,google-api-services-oauth2,google-http-client,google-http-client-apache-v2,google-http-client-gson,google-http-client-jackson2,google-oauth-client,grpc-context,j2objc-annotations,opencensus-api,opencensus-contrib-http-util</hpi.bundledArtifacts>
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
     <jenkins.baseline>2.504</jenkins.baseline>
     <jenkins.version>${jenkins.baseline}.3</jenkins.version>

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/JsonServiceAccountConfig.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/JsonServiceAccountConfig.java
@@ -20,7 +20,6 @@ import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.client.util.PemReader;
 import com.google.api.client.util.Strings;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -136,7 +135,6 @@ public class JsonServiceAccountConfig extends ServiceAccountConfig {
         return path.replaceFirst("^.+[/\\\\]", "");
     }
 
-    @SuppressFBWarnings("RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE")
     private Object readResolve() {
         if (secretJsonKey == null) {
             // google-oauth-plugin < 0.7

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/P12ServiceAccountConfig.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/P12ServiceAccountConfig.java
@@ -18,7 +18,6 @@ package com.google.jenkins.plugins.credentials.oauth;
 import com.cloudbees.plugins.credentials.SecretBytes;
 import com.google.api.client.util.Strings;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.util.FormValidation;
 import java.io.ByteArrayInputStream;
@@ -130,7 +129,6 @@ public class P12ServiceAccountConfig extends ServiceAccountConfig {
         return path.replaceFirst("^.+[/\\\\]", "");
     }
 
-    @SuppressFBWarnings("RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE")
     private Object readResolve() {
         if (secretP12Key == null) {
             // google-oauth-plugin < 0.7

--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/RemotableGoogleCredentials.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/RemotableGoogleCredentials.java
@@ -43,9 +43,6 @@ final class RemotableGoogleCredentials extends GoogleRobotCredentials {
      * is {@code package-private}. This should only be called from {@link
      * GoogleRobotCredentials#forRemote}.
      */
-    @SuppressFBWarnings(
-            value = "NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE",
-            justification = "False positive from what I can see in Ordering.natural().nullsFirst()")
     public RemotableGoogleCredentials(
             GoogleRobotCredentials credentials,
             GoogleOAuth2ScopeRequirement requirement,


### PR DESCRIPTION
## Prepare for Java 25

Java 25 will release Sep 16, 2025 and the Jenkins project wants to support it soon after it is released.  This pull request updates the parent pom to a version that compiles and passes tests with Java 25.

Require Jenkins 2.504.3 or newer (optional, but recommended)

* https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/

Explicitly declare bundled dependencies

Avoid accidental addition of new dependencies when existing dependencies are updated.

From pull request:

* https://github.com/jenkinsci/maven-hpi-plugin/pull/771

### Testing done

Confirmed that automated tests pass with Java 25.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
